### PR TITLE
add rust toolchain file back

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"


### PR DESCRIPTION
- Means don't have to change globally to nightly
- Opens the door to pinning a specific nightly version in the future, for less variability.