### PR TITLE
uart: Try splitting UART RX into two so the read is always pending.

### DIFF
--- a/src/serial.rs
+++ b/src/serial.rs
@@ -3,8 +3,8 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, pipe::Pipe};
 use embedded_io_async::{Read, Write};
 
 // Espressif specific crates
-use esp_hal::{uart::{Error::FifoOverflowed, Uart, UartRx}, Async};
-use esp_println::{dbg, println};
+use esp_hal::{uart::{RxError::FifoOverflowed, Uart, UartRx}, Async};
+use esp_println::println;
 
 /// Forwards an incoming SSH connection to/from the local UART, until
 /// the connection drops

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -162,8 +162,8 @@ pub async fn start(spawner: Spawner) -> Result<(), sunset::Error> {
 
     let uart = Uart::new(peripherals.UART1, uart_config)
         .unwrap()
-        .with_rx(peripherals.GPIO12)
-        .with_tx(peripherals.GPIO13)
+        .with_rx(peripherals.GPIO11)
+        .with_tx(peripherals.GPIO10)
         .into_async();
 
     // Start accepting SSH connections and redirect them to the UART later on


### PR DESCRIPTION
This doesn't really work, still get intermittent RX FIFO overflows.