### PR TITLE
Add build options for all ESP32 wifi targets using cargo features.

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,12 +5,6 @@ build-esp32c3 = "build --release --target riscv32imc-unknown-none-elf --features
 build-esp32c6 = "build --release --target riscv32imac-unknown-none-elf --features esp32c6"
 build-esp32s2 = "build --release --target xtensa-esp32s2-none-elf --features esp32s2"
 build-esp32s3 = "build --release --target xtensa-esp32s3-none-elf --features esp32s3"
-run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
-run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"
-run-esp32c3 = "run --release --target riscv32imc-unknown-none-elf --features esp32c3"
-run-esp32c6 = "run --release --target riscv32imac-unknown-none-elf --features esp32c6"
-run-esp32s2 = "run --release --target xtensa-esp32s2-none-elf --features esp32s2"
-run-esp32s3 = "run --release --target xtensa-esp32s3-none-elf --features esp32s3"
 
 run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
 run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -3,14 +3,14 @@ build-esp32   = "build --release --target xtensa-esp32-none-elf --features esp32
 build-esp32c2 = "build --release --target riscv32imc-unknown-none-elf --features esp32c2"
 build-esp32c3 = "build --release --target riscv32imc-unknown-none-elf --features esp32c3"
 build-esp32c6 = "build --release --target riscv32imac-unknown-none-elf --features esp32c6"
-build-esp32s2 = "build --release --target xtensa-esp32s2-none-elf --features esp32s2"
+build-esp32s2 = "build --profile esp32s2 --target xtensa-esp32s2-none-elf --features esp32s2"
 build-esp32s3 = "build --release --target xtensa-esp32s3-none-elf --features esp32s3"
 
 run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
 run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"
 run-esp32c3 = "run --release --target riscv32imc-unknown-none-elf --features esp32c3"
 run-esp32c6 = "run --release --target riscv32imac-unknown-none-elf --features esp32c6"
-run-esp32s2 = "run --release --target xtensa-esp32s2-none-elf --features esp32s2"
+run-esp32s2 = "run --profile esp32s2 --target xtensa-esp32s2-none-elf --features esp32s2"
 run-esp32s3 = "run --release --target xtensa-esp32s3-none-elf --features esp32s3"
 
 [target.xtensa-esp32-none-elf]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,16 +2,22 @@
 build-esp32   = "build --release --target xtensa-esp32-none-elf --features esp32"
 build-esp32c2 = "build --release --target riscv32imc-unknown-none-elf --features esp32c2"
 build-esp32c3 = "build --release --target riscv32imc-unknown-none-elf --features esp32c3"
+#build-esp32c5 = "build --release --target riscv32imac-unknown-none-elf --features esp32c5"
 build-esp32c6 = "build --release --target riscv32imac-unknown-none-elf --features esp32c6"
 build-esp32s2 = "build --profile esp32s2 --target xtensa-esp32s2-none-elf --features esp32s2"
 build-esp32s3 = "build --release --target xtensa-esp32s3-none-elf --features esp32s3"
+#build-esp32p4 = "build --release --target riscv32imac-unknown-none-elf --features esp32p4"
 
 run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
 run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"
 run-esp32c3 = "run --release --target riscv32imc-unknown-none-elf --features esp32c3"
+# Available but not supported by esp-hal (yet).
+#run-esp32c5 = "run --release --target riscv32imac-unknown-none-elf --features esp32c5"
 run-esp32c6 = "run --release --target riscv32imac-unknown-none-elf --features esp32c6"
 run-esp32s2 = "run --profile esp32s2 --target xtensa-esp32s2-none-elf --features esp32s2"
 run-esp32s3 = "run --release --target xtensa-esp32s3-none-elf --features esp32s3"
+# Delays with the esp32p4 silicon, not widely available yet:https://github.com/esp-rs/esp-hal/pull/1461
+#run-esp32p4 = "run --release --target riscv32imac-unknown-none-elf --features esp32p4"
 
 [target.xtensa-esp32-none-elf]
 runner = "espflash flash --baud=921600 --monitor --chip esp32"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,11 +2,11 @@
 build-esp32   = "build --release --target xtensa-esp32-none-elf --features esp32"
 build-esp32c2 = "build --release --target riscv32imc-unknown-none-elf --features esp32c2"
 build-esp32c3 = "build --release --target riscv32imc-unknown-none-elf --features esp32c3"
+# Available but not supported by esp-hal (yet).
 #build-esp32c5 = "build --release --target riscv32imac-unknown-none-elf --features esp32c5"
 build-esp32c6 = "build --release --target riscv32imac-unknown-none-elf --features esp32c6"
 build-esp32s2 = "build --profile esp32s2 --target xtensa-esp32s2-none-elf --features esp32s2"
 build-esp32s3 = "build --release --target xtensa-esp32s3-none-elf --features esp32s3"
-#build-esp32p4 = "build --release --target riscv32imac-unknown-none-elf --features esp32p4"
 
 run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
 run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"
@@ -16,8 +16,6 @@ run-esp32c3 = "run --release --target riscv32imc-unknown-none-elf --features esp
 run-esp32c6 = "run --release --target riscv32imac-unknown-none-elf --features esp32c6"
 run-esp32s2 = "run --profile esp32s2 --target xtensa-esp32s2-none-elf --features esp32s2"
 run-esp32s3 = "run --release --target xtensa-esp32s3-none-elf --features esp32s3"
-# Delays with the esp32p4 silicon, not widely available yet:https://github.com/esp-rs/esp-hal/pull/1461
-#run-esp32p4 = "run --release --target riscv32imac-unknown-none-elf --features esp32p4"
 
 [target.xtensa-esp32-none-elf]
 runner = "espflash flash --baud=921600 --monitor --chip esp32"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,19 +1,32 @@
-#[target.xtensa-esp32s3-none-elf]
+[alias]
+build-esp32   = "build --release --target xtensa-esp32-none-elf --features esp32"
+build-esp32c2 = "build --release --target riscv32imc-unknown-none-elf --features esp32c2"
+build-esp32c3 = "build --release --target riscv32imc-unknown-none-elf --features esp32c3"
+build-esp32c6 = "build --release --target riscv32imac-unknown-none-elf --features esp32c6"
+build-esp32s2 = "build --release --target xtensa-esp32s2-none-elf --features esp32s2"
+build-esp32s3 = "build --release --target xtensa-esp32s3-none-elf --features esp32s3"
+
+[target.xtensa-esp32-none-elf]
+runner = "espflash flash --baud=921600 --monitor --chip esp32"
+rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32"']
+[target.riscv32imc-unknown-none-elf]
+runner = "espflash flash --baud=921600 --monitor"
+rustflags = [ "-C", "force-frame-pointers"]
 [target.riscv32imac-unknown-none-elf]
 runner = "espflash flash --baud=921600 --monitor"
+rustflags = [ "-C", "force-frame-pointers"]
+[target.xtensa-esp32s2-none-elf]
+runner = "espflash flash --baud=921600 --monitor --chip esp32s2"
+rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32s2"']
+[target.xtensa-esp32s3-none-elf]
+runner = "espflash flash --baud=921600 --monitor --chip esp32s3"
+rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32s3"']
 
 
 [env]
 ESP_LOG="INFO"
 
-[build]
-rustflags = [
-#  "-C", "link-arg=-nostartfiles",
-  "-C", "force-frame-pointers",
-]
-
-#target = "xtensa-esp32s3-none-elf"
 target = "riscv32imac-unknown-none-elf"
 
-#[unstable]
-#build-std = ["core"]
+[unstable]
+build-std = ["core", "alloc"]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,12 @@ build-esp32c3 = "build --release --target riscv32imc-unknown-none-elf --features
 build-esp32c6 = "build --release --target riscv32imac-unknown-none-elf --features esp32c6"
 build-esp32s2 = "build --release --target xtensa-esp32s2-none-elf --features esp32s2"
 build-esp32s3 = "build --release --target xtensa-esp32s3-none-elf --features esp32s3"
+run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
+run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"
+run-esp32c3 = "run --release --target riscv32imc-unknown-none-elf --features esp32c3"
+run-esp32c6 = "run --release --target riscv32imac-unknown-none-elf --features esp32c6"
+run-esp32s2 = "run --release --target xtensa-esp32s2-none-elf --features esp32s2"
+run-esp32s3 = "run --release --target xtensa-esp32s3-none-elf --features esp32s3"
 
 run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
 run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,6 +6,13 @@ build-esp32c6 = "build --release --target riscv32imac-unknown-none-elf --feature
 build-esp32s2 = "build --release --target xtensa-esp32s2-none-elf --features esp32s2"
 build-esp32s3 = "build --release --target xtensa-esp32s3-none-elf --features esp32s3"
 
+run-esp32   = "run --release --target xtensa-esp32-none-elf --features esp32"
+run-esp32c2 = "run --release --target riscv32imc-unknown-none-elf --features esp32c2"
+run-esp32c3 = "run --release --target riscv32imc-unknown-none-elf --features esp32c3"
+run-esp32c6 = "run --release --target riscv32imac-unknown-none-elf --features esp32c6"
+run-esp32s2 = "run --release --target xtensa-esp32s2-none-elf --features esp32s2"
+run-esp32s3 = "run --release --target xtensa-esp32s3-none-elf --features esp32s3"
+
 [target.xtensa-esp32-none-elf]
 runner = "espflash flash --baud=921600 --monitor --chip esp32"
 rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32"']

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,8 @@ jobs:
             # RISC-V devices:
             { soc: "esp32c2", toolchain: "stable" },
             { soc: "esp32c3", toolchain: "stable" },
+#            { soc: "esp32c5", toolchain: "stable" },
+#            { soc: "esp32p4", toolchain: "stable" },
             { soc: "esp32c6", toolchain: "stable" },
             # Xtensa devices:
             { soc: "esp32", toolchain: "esp" },

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,22 +7,49 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   build:
+    name: Build ${{ matrix.device.soc }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        device: [
+            # RISC-V devices:
+            { soc: "esp32c2", toolchain: "stable" },
+            { soc: "esp32c3", toolchain: "stable" },
+            { soc: "esp32c6", toolchain: "stable" },
+            # Xtensa devices:
+            { soc: "esp32", toolchain: "esp" },
+            { soc: "esp32s2", toolchain: "esp" },
+            { soc: "esp32s3", toolchain: "esp" },
+        ]
     steps:
       - name: Cache
         uses: mozilla-actions/sccache-action@v0.0.7
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust toolchain for RISC-V
+        if: ${{ !contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
+        uses: dtolnay/rust-toolchain@v1
         with:
-          toolchain: 1.86.0
-      - name: Install RISCV toolchain (ESP32-C6)
-        run: |
-          rustup toolchain install stable --component rust-src
-          rustup target add riscv32imac-unknown-none-elf
+          target: riscv32imc-unknown-none-elf,riscv32imac-unknown-none-elf
+          toolchain: stable
+          components: rust-src
+      - name: Setup Rust toolchain for Xtensa
+        if: ${{ contains(fromJson('["esp32", "esp32s2", "esp32s3"]'), matrix.device.soc) }}
+        uses: esp-rs/xtensa-toolchain@v1.5
+        with:
+          ldproxy: false
+          version: 1.86.0.0
+
       - name: Build project
-        run: cargo build --release
+        run: cargo +${{ matrix.device.toolchain }} build-${{ matrix.device.soc }}
+
+      - name: Check lints and format
+        if: ${{ contains(fromJson('["esp32c6"]'), matrix.device.soc) }}
+        run: |
+          cargo +${{ matrix.device.toolchain }} clippy --features ${{ matrix.device.soc }} --target riscv32imac-unknown-none-elf -- -D warnings
+          cargo +${{ matrix.device.toolchain }} fmt -- --check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -476,6 +476,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "embassy-usb-driver"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fc247028eae04174b6635104a35b1ed336aabef4654f5e87a8f32327d231970"
+
+[[package]]
+name = "embassy-usb-synopsys-otg"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e753b23799329780c7ac434264026d0422044d6649ed70a73441b14a6436d7"
+dependencies = [
+ "critical-section",
+ "embassy-sync 0.6.2",
+ "embassy-usb-driver",
+]
+
+[[package]]
 name = "embedded-can"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +635,7 @@ checksum = "e4cd70abe47945c9116972781b5c05277ad855a5f5569fe2afd3e2e61a103cc0"
 dependencies = [
  "esp-build",
  "esp-println",
+ "semihosting",
 ]
 
 [[package]]
@@ -658,6 +676,8 @@ dependencies = [
  "embassy-embedded-hal",
  "embassy-futures",
  "embassy-sync 0.6.2",
+ "embassy-usb-driver",
+ "embassy-usb-synopsys-otg",
  "embedded-can",
  "embedded-hal 1.0.0",
  "embedded-hal-async",
@@ -669,7 +689,13 @@ dependencies = [
  "esp-hal-procmacros",
  "esp-metadata",
  "esp-riscv-rt",
+ "esp-synopsys-usb-otg",
+ "esp32",
+ "esp32c2",
+ "esp32c3",
  "esp32c6",
+ "esp32s2",
+ "esp32s3",
  "fugit",
  "instability",
  "nb 1.1.0",
@@ -680,6 +706,7 @@ dependencies = [
  "serde",
  "strum 0.27.1",
  "ufmt-write",
+ "usb-device",
  "void",
  "xtensa-lx",
  "xtensa-lx-rt",
@@ -760,6 +787,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp-synopsys-usb-otg"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8938451cb19032f13365328ea66ab38c8d16deecdf322067442297110eb74468"
+dependencies = [
+ "critical-section",
+ "embedded-hal 0.2.7",
+ "ral-registers",
+ "usb-device",
+ "vcell",
+]
+
+[[package]]
 name = "esp-wifi"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -786,6 +826,7 @@ dependencies = [
  "portable-atomic",
  "portable_atomic_enum",
  "rand_core",
+ "xtensa-lx-rt",
 ]
 
 [[package]]
@@ -798,10 +839,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "esp32"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d9b774d7a2c96550a5c25016c2abd33370ebac60e534484b7bca344ecb8a3d6"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
+name = "esp32c2"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f7037cfa7c93574b0891062f980a75ae97e9d6c93dcaff3e060b37cf1281c59"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
+name = "esp32c3"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1bbcfa3ab2979171263db80804dabc38bdd45450c7eb775ee3f81d552cf0ba"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
 name = "esp32c6"
 version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ff2a4e1d1b0cb2517af20766004b8e8fb4612043f0b0569703cc90d1880ede4"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
+name = "esp32s2"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a22733ee6f4bb08e3113df6651b2c350f37c44314017476e354ec951a55465e9"
+dependencies = [
+ "critical-section",
+ "vcell",
+]
+
+[[package]]
+name = "esp32s3"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6d20f119410092abfbc65e46f9362015a7110023528f0dbe855cab80c38ca8"
 dependencies = [
  "critical-section",
  "vcell",
@@ -1143,6 +1234,9 @@ name = "portable-atomic"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "350e9b48cbc6b0e028b0473b114454c6316e57336ee184ceab6e53f72c178b3e"
+dependencies = [
+ "critical-section",
+]
 
 [[package]]
 name = "portable_atomic_enum"
@@ -1227,6 +1321,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7a31eed1591dcbc95d92ad7161908e72f4677f8fabf2a32ca49b4237cbf211"
 
 [[package]]
+name = "ral-registers"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46b71a9d9206e8b46714c74255adcaea8b11e0350c1d8456165073c3f75fc81a"
+
+[[package]]
 name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1290,6 +1390,12 @@ name = "rustversion"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
+
+[[package]]
+name = "semihosting"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e1c7d2b77d80283c750a39c52f1ab4d17234e8f30bca43550f5b2375f41d5f"
 
 [[package]]
 name = "semver"
@@ -1650,6 +1756,16 @@ checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
  "crypto-common",
  "subtle",
+]
+
+[[package]]
+name = "usb-device"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98816b1accafbb09085168b90f27e93d790b4bfa19d883466b5e53315b5f06a6"
+dependencies = [
+ "heapless",
+ "portable-atomic",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -118,11 +118,3 @@ esp32s3 = [
     "esp-println/esp32s3",
     "embassy-executor/task-arena-size-40960",
 ]
-#esp32p4 = [
-#    "esp-hal/esp32p4",
-#    "esp-backtrace/esp32p4",
-#    "esp-wifi/esp32p4",
-#    "esp-hal-embassy/esp32p4",
-#    "esp-println/esp32p4",
-#    "embassy-executor/task-arena-size-40960",
-#]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,14 @@ esp32c3 = [
     "esp-println/esp32c3",
     "embassy-executor/task-arena-size-40960",
 ]
+#esp32c5 = [
+#    "esp-hal/esp32c5",
+#    "esp-backtrace/esp32c5",
+#    "esp-wifi/esp32c5",
+#    "esp-hal-embassy/esp32c5",
+#    "esp-println/esp32c5",
+#    "embassy-executor/task-arena-size-40960",
+#]
 esp32c6 = [
     "esp-hal/esp32c6",
     "esp-backtrace/esp32c6",
@@ -110,3 +118,11 @@ esp32s3 = [
     "esp-println/esp32s3",
     "embassy-executor/task-arena-size-40960",
 ]
+#esp32p4 = [
+#    "esp-hal/esp32p4",
+#    "esp-backtrace/esp32p4",
+#    "esp-wifi/esp32p4",
+#    "esp-hal-embassy/esp32p4",
+#    "esp-println/esp32p4",
+#    "embassy-executor/task-arena-size-40960",
+#]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 cfg-if = "1.0.0"
 ed25519-dalek = { version = "2", default-features = false }
-embassy-executor = { version = "0.7", features = ["task-arena-size-40960"]}
+embassy-executor = { version = "0.7"}
 embassy-net = { version = "0.6", features = ["tcp", "udp", "dhcpv4", "medium-ethernet"] }
 smoltcp = { version = "0.12", default-features = false, features = ["medium-ethernet", "socket-raw"]}
 embassy-time = { version = "0.4" }
@@ -54,6 +54,11 @@ lto = 'fat'
 opt-level = 3
 overflow-checks = false
 
+[profile.esp32s2]
+inherits = "release"
+opt-level = "s"  # Optimize for size.
+
+
 [features]
 
 # MCU options
@@ -63,6 +68,7 @@ esp32 = [
     "esp-wifi/esp32",
     "esp-hal-embassy/esp32",
     "esp-println/esp32",
+    "embassy-executor/task-arena-size-40960",
 ]
 esp32c2 = [
     "esp-hal/esp32c2",
@@ -70,6 +76,7 @@ esp32c2 = [
     "esp-wifi/esp32c2",
     "esp-hal-embassy/esp32c2",
     "esp-println/esp32c2",
+    "embassy-executor/task-arena-size-40960",
 ]
 esp32c3 = [
     "esp-hal/esp32c3",
@@ -77,6 +84,7 @@ esp32c3 = [
     "esp-wifi/esp32c3",
     "esp-hal-embassy/esp32c3",
     "esp-println/esp32c3",
+    "embassy-executor/task-arena-size-40960",
 ]
 esp32c6 = [
     "esp-hal/esp32c6",
@@ -84,6 +92,7 @@ esp32c6 = [
     "esp-wifi/esp32c6",
     "esp-hal-embassy/esp32c6",
     "esp-println/esp32c6",
+    "embassy-executor/task-arena-size-40960",
 ]
 esp32s2 = [
     "esp-hal/esp32s2",
@@ -91,6 +100,7 @@ esp32s2 = [
     "esp-wifi/esp32s2",
     "esp-hal-embassy/esp32s2",
     "esp-println/esp32s2",
+    "embassy-executor/task-arena-size-32768",
 ]
 esp32s3 = [
     "esp-hal/esp32s3",
@@ -98,4 +108,5 @@ esp32s3 = [
     "esp-wifi/esp32s3",
     "esp-hal-embassy/esp32s3",
     "esp-println/esp32s3",
+    "embassy-executor/task-arena-size-40960",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,14 @@ embassy-time = { version = "0.4" }
 embedded-io-async = "0.6.0"
 esp-alloc = "0.7"
 esp-backtrace = { version = "0.15", features = [
-#    "esp32s3",
-    "esp32c6",
     "exception-handler",
     "panic-handler",
     "println",
 ] }
-# esp-hal = { version = "0.20", features = [ "esp32s3", "async" ] }
-# esp-hal-embassy = { version = "0.3", features = ["esp32s3"] }
-# esp-println = { version = "0.11", features = ["esp32s3", "log"] }
-# esp-wifi = { version = "0.8.0", features = ["esp32s3", "wifi", "wifi-default", "utils", "smoltcp", "async", "embassy-net"] }
-esp-hal = { version = "1.0.0-beta.0", features = [ "esp32c6", "unstable" ] }
-esp-hal-embassy = { version = "0.7", features = ["esp32c6"] }
-esp-println = { version = "0.13", features = ["esp32c6", "log"] }
-esp-wifi = { version = "0.13", features = ["esp32c6", "wifi", "esp-alloc"] }
+esp-hal = { version = "1.0.0-beta.0", features = [ "unstable" ] }
+esp-hal-embassy = { version = "0.7"}
+esp-println = { version = "0.13", features = ["log"] }
+esp-wifi = { version = "0.13", features = ["wifi", "esp-alloc"] }
 hex = { version = "0.4", default-features = false }
 log = { version = "0.4" }
 static_cell = { version = "2", features = ["nightly"] }
@@ -61,4 +55,47 @@ opt-level = 3
 overflow-checks = false
 
 [features]
-esp32 = []
+
+# MCU options
+esp32 = [
+    "esp-hal/esp32",
+    "esp-backtrace/esp32",
+    "esp-wifi/esp32",
+    "esp-hal-embassy/esp32",
+    "esp-println/esp32",
+]
+esp32c2 = [
+    "esp-hal/esp32c2",
+    "esp-backtrace/esp32c2",
+    "esp-wifi/esp32c2",
+    "esp-hal-embassy/esp32c2",
+    "esp-println/esp32c2",
+]
+esp32c3 = [
+    "esp-hal/esp32c3",
+    "esp-backtrace/esp32c3",
+    "esp-wifi/esp32c3",
+    "esp-hal-embassy/esp32c3",
+    "esp-println/esp32c3",
+]
+esp32c6 = [
+    "esp-hal/esp32c6",
+    "esp-backtrace/esp32c6",
+    "esp-wifi/esp32c6",
+    "esp-hal-embassy/esp32c6",
+    "esp-println/esp32c6",
+]
+esp32s2 = [
+    "esp-hal/esp32s2",
+    "esp-backtrace/esp32s2",
+    "esp-wifi/esp32s2",
+    "esp-hal-embassy/esp32s2",
+    "esp-println/esp32s2",
+]
+esp32s3 = [
+    "esp-hal/esp32s3",
+    "esp-backtrace/esp32s3",
+    "esp-wifi/esp32s3",
+    "esp-hal-embassy/esp32s3",
+    "esp-println/esp32s3",
+]

--- a/README.md
+++ b/README.md
@@ -33,12 +33,41 @@ A "low level to SSH Swiss army knife".
 
 Rust versions are controlled via `rust-toolchain.toml` and the equivalent defined on the CI workflow.
 
-On a fresh system the following should be enough to build and run on an ESP32-C6 dev board.
-
+Required for all targets:
 ```
 rustup toolchain install stable --component rust-src
+```
+
+On a fresh system the following should be enough to build and run on an ESP32-C6 dev board.
+```
 rustup target add riscv32imac-unknown-none-elf
-cargo build --release
+cargo build-esp32c6
+```
+
+Building for ESP32-C2 / ESP32-C3:
+```
+rustup target add riscv32imc-unknown-none-elf
+cargo build-esp32c2
+cargo build-esp32c3
+```
+
+Building for ESP32 / ESP32-S2 / ESP32-S3 (Xtensa Cores) -
+Install esp toolchain first: https://github.com/esp-rs/espup
+```
+cargo install espup
+espup install
+$HOME/export-esp.sh
+rustup override set esp
+cargo build-esp32
+cargo build-esp32s2
+cargo build-esp32s3
+```
+
+Alternatively to not use rustup override:
+```
+cargo +esp build-esp32
+cargo +esp build-esp32s2
+cargo +esp build-esp32s3
 ```
 
 Running on the target:

--- a/README.md
+++ b/README.md
@@ -36,22 +36,26 @@ Rust versions are controlled via `rust-toolchain.toml` and the equivalent define
 Required for all targets:
 ```
 rustup toolchain install stable --component rust-src
+cargo install espflash
 ```
 
 On a fresh system the following should be enough to build and run on an ESP32-C6 dev board.
 ```
 rustup target add riscv32imac-unknown-none-elf
 cargo build-esp32c6
+cargo run-esp32c6
 ```
 
-Building for ESP32-C2 / ESP32-C3:
+Build and run for ESP32-C2 / ESP32-C3:
 ```
 rustup target add riscv32imc-unknown-none-elf
 cargo build-esp32c2
 cargo build-esp32c3
+cargo run-esp32c2
+cargo run-esp32c3
 ```
 
-Building for ESP32 / ESP32-S2 / ESP32-S3 (Xtensa Cores) -
+Build for ESP32 / ESP32-S2 / ESP32-S3 (Xtensa Cores) -
 Install esp toolchain first: https://github.com/esp-rs/espup
 ```
 cargo install espup
@@ -62,6 +66,12 @@ cargo build-esp32
 cargo build-esp32s2
 cargo build-esp32s3
 ```
+Running on the target:
+```
+cargo run-esp32
+cargo run-esp32s2
+cargo run-esp32s3
+```
 
 Alternatively to not use rustup override:
 ```
@@ -71,10 +81,10 @@ cargo +esp build-esp32s3
 ```
 
 Running on the target:
-
 ```
-cargo install espflash
-cargo run --release
+cargo +esp run-esp32
+cargo +esp run-esp32s2
+cargo +esp run-esp32s3
 ```
 
 # Example usecases

--- a/src/espressif/buffered_uart.rs
+++ b/src/espressif/buffered_uart.rs
@@ -1,12 +1,12 @@
+use embassy_futures::select::select;
 /// Wrapper around bidirectional embassy-sync Pipes, in order to handle UART
 /// RX/RX happening in an InterruptExecutor at higher priority.
 ///
 /// Doesn't implement the InterruptExecutor, in the task in the app should await
 /// the 'run' async function.
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, pipe::Pipe};
-use embassy_futures::select::select;
-use esp_hal::Async;
 use esp_hal::uart::Uart;
+use esp_hal::Async;
 
 // Sizes of the software buffers. Inward is more
 // important as an overrun here drops bytes. A full outward
@@ -23,13 +23,14 @@ pub struct BufferedUart {
     inward: Pipe<CriticalSectionRawMutex, INWARD_BUF_SZ>,
 }
 
-pub struct Config {
-
-}
+pub struct Config {}
 
 impl BufferedUart {
     pub fn new() -> Self {
-        BufferedUart { outward: Pipe::new(), inward: Pipe::new() }
+        BufferedUart {
+            outward: Pipe::new(),
+            inward: Pipe::new(),
+        }
     }
 
     /// Transfer data between the UART and the buffer struct.
@@ -70,7 +71,6 @@ impl BufferedUart {
     pub fn reconfigure(&self, _config: Config) {
         todo!();
     }
-
 }
 
 impl Default for BufferedUart {

--- a/src/espressif/mod.rs
+++ b/src/espressif/mod.rs
@@ -1,3 +1,3 @@
+pub mod buffered_uart;
 pub mod net;
 pub mod rng;
-pub mod buffered_uart;

--- a/src/espressif/net.rs
+++ b/src/espressif/net.rs
@@ -12,9 +12,7 @@ use esp_hal::peripherals::WIFI;
 use esp_hal::rng::Rng;
 use esp_println::{dbg, println};
 
-use esp_wifi::wifi::{
-    AccessPointConfiguration, Configuration, WifiDevice, WifiController,
-};
+use esp_wifi::wifi::{AccessPointConfiguration, Configuration, WifiController, WifiDevice};
 use esp_wifi::wifi::{WifiEvent, WifiState};
 use esp_wifi::EspWifiController;
 
@@ -49,8 +47,7 @@ pub async fn if_up(
     rng: &mut Rng,
 ) -> Result<Stack<'static>, sunset::Error> {
     let wifi_init = &*mk_static!(EspWifiController<'static>, wifi_controller);
-    let (controller, interfaces) =
-        esp_wifi::wifi::new(wifi_init, wifi).unwrap();
+    let (controller, interfaces) = esp_wifi::wifi::new(wifi_init, wifi).unwrap();
 
     let gw_ip_addr_str = GW_IP_ADDR_ENV.unwrap_or("192.168.0.1");
     let gw_ip_addr = Ipv4Addr::from_str(gw_ip_addr_str).expect("failed to parse gateway ip");
@@ -92,9 +89,7 @@ pub async fn if_up(
     Ok(ap_stack)
 }
 
-pub async fn accept_requests(
-    stack: Stack<'static>,
-    uart: &BufferedUart) -> ! {
+pub async fn accept_requests(stack: Stack<'static>, uart: &BufferedUart) -> ! {
     let rx_buffer = mk_static!([u8; 1536], [0; 1536]);
     let tx_buffer = mk_static!([u8; 1536], [0; 1536]);
 
@@ -119,7 +114,7 @@ pub async fn accept_requests(
             Ok(_) => (),
             Err(e) => {
                 println!("SSH client fatal error: {}", e);
-            },
+            }
         };
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,22 @@
 use core::marker::Sized;
 use esp_alloc as _;
 use esp_backtrace as _;
-use esp_hal::{gpio::AnyPin, interrupt::{software::SoftwareInterruptControl, Priority}, peripherals::UART1, rng::Rng, timer::timg::TimerGroup, uart::{Config, RxConfig, Uart}};
+use esp_hal::{
+    gpio::AnyPin,
+    interrupt::{software::SoftwareInterruptControl, Priority},
+    peripherals::UART1,
+    rng::Rng,
+    timer::timg::TimerGroup,
+    uart::{Config, RxConfig, Uart},
+};
 use esp_hal_embassy::InterruptExecutor;
 
 use embassy_executor::Spawner;
-use ssh_stamp::espressif::{net::{accept_requests, if_up}, rng, buffered_uart::BufferedUart};
+use ssh_stamp::espressif::{
+    buffered_uart::BufferedUart,
+    net::{accept_requests, if_up},
+    rng,
+};
 use static_cell::StaticCell;
 
 #[esp_hal_embassy::main]
@@ -17,9 +28,7 @@ async fn main(spawner: Spawner) -> ! {
     esp_println::logger::init_logger_from_env();
 
     // System init
-    let peripherals = esp_hal::init({
-        esp_hal::Config::default()
-    });
+    let peripherals = esp_hal::init(esp_hal::Config::default());
     let mut rng = Rng::new(peripherals.RNG);
     let timg0 = TimerGroup::new(peripherals.TIMG0);
 
@@ -39,12 +48,15 @@ async fn main(spawner: Spawner) -> ! {
     let wifi_controller = esp_wifi::init(timg0.timer0, rng, peripherals.RADIO_CLK).unwrap();
 
     // Bring up the network interface and start accepting SSH connections.
-    let tcp_stack = if_up(spawner, wifi_controller, peripherals.WIFI, &mut rng).await.unwrap();
+    let tcp_stack = if_up(spawner, wifi_controller, peripherals.WIFI, &mut rng)
+        .await
+        .unwrap();
 
     // Set up software buffered UART to run in a higher priority InterruptExecutor
     let uart_buf = UART_BUF.init_with(BufferedUart::new);
     let software_interrupts = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-    let interrupt_exeuctor = INT_EXECUTOR.init_with(|| InterruptExecutor::new(software_interrupts.software_interrupt0));
+    let interrupt_exeuctor =
+        INT_EXECUTOR.init_with(|| InterruptExecutor::new(software_interrupts.software_interrupt0));
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
             let interrupt_spawner = interrupt_exeuctor.start(Priority::Priority1);
@@ -52,8 +64,13 @@ async fn main(spawner: Spawner) -> ! {
             let interrupt_spawner = interrupt_exeuctor.start(Priority::Priority10);
         }
     }
+    cfg_if::cfg_if! {
+        if #[cfg(not(feature = "esp32c2"))] {
     interrupt_spawner.spawn(uart_task(uart_buf, peripherals.UART1, peripherals.GPIO11.into(), peripherals.GPIO10.into())).unwrap();
-
+        } else {
+            interrupt_spawner.spawn(uart_task(uart_buf, peripherals.UART1, peripherals.GPIO9.into(), peripherals.GPIO10.into())).unwrap();
+        }
+    }
     accept_requests(tcp_stack, uart_buf).await;
 }
 
@@ -62,10 +79,18 @@ static UART_BUF: StaticCell<BufferedUart> = StaticCell::new();
 static INT_EXECUTOR: StaticCell<InterruptExecutor<0>> = StaticCell::new();
 
 #[embassy_executor::task]
-async fn uart_task(buffer: &'static BufferedUart, uart_periph: UART1, rx_pin: AnyPin, tx_pin: AnyPin) {
+async fn uart_task(
+    buffer: &'static BufferedUart,
+    uart_periph: UART1,
+    rx_pin: AnyPin,
+    tx_pin: AnyPin,
+) {
     // Hardware UART setup
-    let uart_config = Config::default()
-        .with_rx(RxConfig::default().with_fifo_full_threshold(16).with_timeout(1));
+    let uart_config = Config::default().with_rx(
+        RxConfig::default()
+            .with_fifo_full_threshold(16)
+            .with_timeout(1),
+    );
 
     let uart = Uart::new(uart_periph, uart_config)
         .unwrap()

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -2,8 +2,8 @@ use embassy_futures::select::select;
 use embedded_io_async::{Read, Write};
 
 // Espressif specific crates
-use esp_println::println;
 use crate::espressif::buffered_uart::BufferedUart;
+use esp_println::println;
 
 /// Forwards an incoming SSH connection to/from the local UART, until
 /// the connection drops
@@ -11,17 +11,18 @@ pub(crate) async fn serial_bridge(
     chanr: impl Read<Error = sunset::Error>,
     chanw: impl Write<Error = sunset::Error>,
     uart: &BufferedUart,
-) -> Result<(), sunset::Error>
-{
+) -> Result<(), sunset::Error> {
     println!("Starting serial <--> SSH bridge");
 
-    select(uart_to_ssh(uart, chanw),
-           ssh_to_uart(chanr, uart)).await;
+    select(uart_to_ssh(uart, chanw), ssh_to_uart(chanr, uart)).await;
     println!("Stopping serial <--> SSH bridge");
     Ok(())
 }
 
-async fn uart_to_ssh(uart_buf: &BufferedUart, mut chanw: impl Write<Error = sunset::Error>) -> Result<(), sunset::Error> {
+async fn uart_to_ssh(
+    uart_buf: &BufferedUart,
+    mut chanw: impl Write<Error = sunset::Error>,
+) -> Result<(), sunset::Error> {
     let mut ssh_tx_buf = [0u8; 512];
     loop {
         let n = uart_buf.read(&mut ssh_tx_buf).await;
@@ -29,7 +30,10 @@ async fn uart_to_ssh(uart_buf: &BufferedUart, mut chanw: impl Write<Error = suns
     }
 }
 
-async fn ssh_to_uart(mut chanr: impl Read<Error = sunset::Error>, uart_buf: &BufferedUart) -> Result<(), sunset::Error> {
+async fn ssh_to_uart(
+    mut chanr: impl Read<Error = sunset::Error>,
+    uart_buf: &BufferedUart,
+) -> Result<(), sunset::Error> {
     let mut uart_tx_buf = [0u8; 64];
     loop {
         let n = chanr.read(&mut uart_tx_buf).await?;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -2,7 +2,6 @@ use core::option::Option::{self, None, Some};
 use core::result::Result;
 use core::writeln;
 
-
 use crate::espressif::buffered_uart::BufferedUart;
 use crate::keys;
 use crate::serial::serial_bridge;
@@ -13,7 +12,6 @@ use embassy_net::tcp::TcpSocket;
 use embassy_sync::blocking_mutex::raw::NoopRawMutex;
 use embassy_sync::channel::Channel;
 use embassy_sync::mutex::Mutex;
-
 
 use heapless::String;
 use sunset::{error, ChanHandle, ServEvent, SignKey};


### PR DESCRIPTION
Initial implementation of [Issue 18](https://github.com/brainstorm/ssh-stamp/issues/18)
- The simplest solution I could see at this point was to implement option 3 and not bring in additional dependencies. Just modify the cargo.toml and config.toml. The target features are achieved using build features and config.toml aliases.
- The xtensa targets require the esp toolchain, so either need `+esp` included in the cargo build commands or the rustup target can be set if only a single target will be used.
- I had to include build-std = ["core", "alloc"] for the xtensa targets to compile but I believe these are esp no-std libraries.

Example commands: 
```
cargo build-esp32
cargo build-esp32c6
```


External issues to be resolved:
1. Xtensa target UART priority issue - Priority10 does not exist for the xtensa targets so #cfg feature was used to change that to Priority1 for those targets.
2. The ESP32-S2 target will currently not compile as the memory is not large enough `Region 'dram_seg' overflowed by 8560 bytes`

It may be useful to do further work and use an environment variable or automatically detect the target so the user only needs to use `cargo build`. The xtask examples I've seen still require the user to use a different command per target.