### PR TITLE
Generates linker map

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,19 +19,19 @@ run-esp32s3 = "run --release --target xtensa-esp32s3-none-elf --features esp32s3
 
 [target.xtensa-esp32-none-elf]
 runner = "espflash flash --baud=921600 --monitor --chip esp32"
-rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32"']
+rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32"', "-C", "link-args=-Map=target/debug/espressif_memory.map"]
 [target.riscv32imc-unknown-none-elf]
 runner = "espflash flash --baud=921600 --monitor"
-rustflags = [ "-C", "force-frame-pointers"]
+rustflags = [ "-C", "force-frame-pointers", "-C", "link-args=-Map=target/debug/espressif_memory.map"]
 [target.riscv32imac-unknown-none-elf]
 runner = "espflash flash --baud=921600 --monitor"
-rustflags = [ "-C", "force-frame-pointers"]
+rustflags = [ "-C", "force-frame-pointers", "-C", "link-args=-Map=target/debug/espressif_memory.map"]
 [target.xtensa-esp32s2-none-elf]
 runner = "espflash flash --baud=921600 --monitor --chip esp32s2"
-rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32s2"']
+rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32s2"', "-C", "link-args=-Map=target/debug/espressif_memory.map"]
 [target.xtensa-esp32s3-none-elf]
 runner = "espflash flash --baud=921600 --monitor --chip esp32s3"
-rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32s3"']
+rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32s3"', "-C", "link-args=-Map=target/debug/espressif_memory.map"]
 
 
 [env]


### PR DESCRIPTION
Aimed at measuring how much objects occupy in different memory regions), a bit of a heavy file:

```
% ls -alh target/debug/espressif_memory.map
-rw-r--r-- 1 rvalls staff 11M May 23 21:12 target/debug/espressif_memory.map
```

Ideally the post-processed output of this `.map` file should tell us what code is overflowing dram_seg on the ESP32S2: https://github.com/esp-rs/esp-hal/blob/main/esp-hal/ld/esp32s2/memory.x