### PR TITLE
buffered_uart: drop oldest bytes if pipe is full

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1545,6 +1545,7 @@ dependencies = [
  "heapless",
  "hex",
  "log",
+ "portable-atomic",
  "smoltcp",
  "ssh-key",
  "static_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ embassy-futures = "0.1"
 edge-dhcp = "0.5"
 edge-nal = "0.5"
 edge-nal-embassy = "0.5"
+portable-atomic = "1.11.0"
 
 [profile.dev]
 # Rust debug is too slow.

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -25,6 +25,12 @@ async fn uart_to_ssh(
 ) -> Result<(), sunset::Error> {
     let mut ssh_tx_buf = [0u8; 512];
     loop {
+        let dropped = uart_buf.check_dropped_bytes();
+        if dropped > 0 {
+            // TODO: should this also go to the SSH client?
+            println!("UART RX dropped {} bytes", dropped);
+        }
+
         let n = uart_buf.read(&mut ssh_tx_buf).await;
         chanw.write_all(&ssh_tx_buf[..n]).await?;
     }


### PR DESCRIPTION
Goals are:

- Prevent the UART FIFO from overflowing under any circumstances.
- Drop the oldest received bytes from the inward pipe (Closes #39).

Tested on ESP32-C6 by uploading `frankenstein.txt` (439KB) via UART and checking:
1. If SSH connection is established, all bytes received correctly via SSH.
2. If SSH connection is not established, bytes are dropped as expected and only the last `INWARD_BUF_SZ` bytes in the file are delivered when an SSH connection is established afterwards.

This should be a fix for the panic in #45 - although it's still possible that bytes are lost if there's an issue with the network connection. Increasing `INWARD_BUF_SZ` would give the SSH-Stamp more time before it had to drop bytes.