### PR TITLE
Pin builds to esp32c6 to appease rust-analyser

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,6 +37,7 @@ rustflags = ["-C", "link-arg=-nostartfiles", '--cfg=feature="esp32s3"']
 [env]
 ESP_LOG="INFO"
 
+[build]
 target = "riscv32imac-unknown-none-elf"
 
 [unstable]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ opt-level = "s"  # Optimize for size.
 
 
 [features]
+default = ["esp32c6"]
 
 # MCU options
 esp32 = [


### PR DESCRIPTION
Suggested by @Autofix in order to have rust-analyser working again on VSCode (which launch `cargo check` and other "regular cargo commands", other than our own scheme (`run-esp32c6`, `build-esp32s3`, etc...).

Those two lines fix the issue, but there are other tentative workarounds, i.e:

```
"rust-analyzer.checkOnSave.command": "cargo check --target riscv32imc-unknown-none-elf --features esp32c3"
does this solve the cargo check issue for a non-default target?
```

Or other potential environment variables-based approaches such as this one described by @Autofix:

```
I looked a bit more into building with environment variables, a potential option is to use CARGO_ALIAS instead of the config.toml, but it still doesnt allow us to override 'build', eg:
CARGO_ALIAS_BUILD_ESP="build --release --target xtensa-esp32-none-elf --features esp32" cargo +esp build-esp
This would at least allow the same command to be run for each target, only changing env variables, but I'm not sure if it actually simplifies anything
```