### PR TITLE
Increase priority of UART interrupt for ESP32/S2/S3 due to blocking.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -66,13 +66,14 @@ async fn main(spawner: Spawner) -> ! {
         .unwrap();
 
     // Set up software buffered UART to run in a higher priority InterruptExecutor
+    // Must be higher priority than esp_rtos (Priority1)
     let uart_buf = UART_BUF.init_with(BufferedUart::new);
     let software_interrupts = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
     let interrupt_executor =
         INT_EXECUTOR.init_with(|| InterruptExecutor::new(software_interrupts.software_interrupt0));
     cfg_if::cfg_if! {
         if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
-            let interrupt_spawner = interrupt_executor.start(Priority::Priority1);
+            let interrupt_spawner = interrupt_executor.start(Priority::Priority3);
         } else {
             let interrupt_spawner = interrupt_executor.start(Priority::Priority10);
         }


### PR DESCRIPTION
During testing of HSM I found that the ESP32 would be able to send unlimited bytes, but after a single byte was read, it would get blocked in both directions while reading the uart rx buffer.
https://github.com/brainstorm/ssh-stamp/blob/ea17833881b6bce0b17f19844d90f572e874aac3/src/espressif/buffered_uart.rs#L57

@projectgus found that esp-rtos runs at Priority 1 so the UART priority must be set higher than that. I tested at Priority 2 but the same block was occurring. Testing at Priority 3 (max) appears to work. 

This PR should not affect anything else so can be easily merged.