### PR TITLE
Unnecessary slice checks for the tlv holder

### DIFF
--- a/ota/src/tlv.rs
+++ b/ota/src/tlv.rs
@@ -191,11 +191,7 @@ impl<'a> TlvsSource<'a> {
             core::mem::size_of::<tlv::OtaTlvType>() + core::mem::size_of::<tlv::OtaTlvLen>();
         if *current_len >= slice_value_start {
             // try reading bytes to complete the value
-            let val_len = tlv::OtaTlvLen::from_be_bytes(
-                tlv_holder[slice_len_start..slice_value_start]
-                    .try_into()
-                    .unwrap(),
-            ) as usize;
+            let val_len = tlv_holder[slice_len_start] as usize;
             debug!(
                 "value length: {}, Source remaining bytes: {}",
                 val_len,


### PR DESCRIPTION
afaik slice_len_start..slice_value_start is exactly 1 byte (size of OtaTlvLen), and we've already verified we have at least slice_value_start bytes in tlv_holder