### PR TITLE
new feature: hil-serial-by-function

### DIFF
--- a/hil/serial-by-function/README.md
+++ b/hil/serial-by-function/README.md
@@ -1,0 +1,67 @@
+# Serial Port Function Linker
+
+Create stable function-based symlinks (for example, `program_esp32`, `com_esp32`) from `/dev/serial/by-id` entries to '/dev/serial/by-function' using a map file.
+
+
+This project installs:
+
+- `/usr/local/bin/link_serials_by_function.sh` (runtime linker)
+- `/etc/systemd/system/link-serials-by-function.service` (systemd oneshot)
+- `/etc/udev/rules.d/99-link-serials-by-function.rules` (udev trigger on add/remove)
+- `/etc/tempfiles.d/serials-by-function.conf` (tmpfiles rule to recreate output dir on boot)
+- `/etc/serials_map.conf` (map serial/by-id to function)
+
+## Why
+
+`/dev/ttyUSB*` numbers can change after reconnect/reboot.
+`/dev/serial/by-id/*` is stable per device.
+This tool maps stable IDs to role names.
+
+## Mapping file format
+
+`serial_id=function_name`
+
+Example (`example_map.conf`):
+
+```conf
+# Map with the name of the serial device as found in /dev/serial/by-id/ folder and 
+# the function (prog_*, com_*, other_*)
+usb-1a86_USB_Single_Serial_5AE7080382-if00=prog_esp32s3
+usb-FTDI_FT232R_USB_UART_AN94725E-if00-port0=com_esp32s2
+usb-1a86_USB_Serial-if00-port0=prog_esp32
+usb-FTDI_FT232R_USB_UART_A300V04K-if00-port0=com_esp32
+usb-Espressif_USB_JTAG_serial_debug_unit_40:4C:CA:8C:E9:7C-if00=prog_esp32c3
+usb-FTDI_FT232R_USB_UART_AV74K0PO-if00-port0=com_esp32c3
+usb-Espressif_USB_JTAG_serial_debug_unit_F0:F5:BD:0E:60:58-if00=prog_esp32c6
+usb-FTDI_FT232R_USB_UART_AT4P96AZ-if00-port0=com_esp32c6
+```
+
+## Install
+
+From serial-by-function folder:
+
+```bash
+chmod +x ./install_serials_by_function.sh
+sudo ./install_serials_by_function.sh config/serial_map.conf /dev/serial/by-function
+```
+
+## Uninstall
+
+To remove the installed service, udev rule, tmpfiles rule, and linker script:
+
+```bash
+chmod +x deploy/uninstall_serials_by_function.sh
+sudo ./deploy/uninstall_serials_by_function.sh
+```
+
+To also remove the installed mapping file (`/etc/serials_map.conf`):
+
+```bash
+sudo ./uninstall_serial_by_function.sh --remove-map
+```
+
+Optional: remove the runtime output directory if it still exists:
+
+```bash
+sudo rm -rf /dev/serial/by-function
+```

--- a/hil/serial-by-function/example_map.conf
+++ b/hil/serial-by-function/example_map.conf
@@ -1,0 +1,10 @@
+# Map with the name of the serial device as found in /dev/serial/by-id/ folder and 
+# the function (prog_*, com_*, other_*)
+usb-1a86_USB_Single_Serial_5AE7080382-if00=prog_esp32s3
+usb-FTDI_FT232R_USB_UART_AN94725E-if00-port0=com_esp32s2
+usb-1a86_USB_Serial-if00-port0=prog_esp32
+usb-FTDI_FT232R_USB_UART_A300V04K-if00-port0=com_esp32
+usb-Espressif_USB_JTAG_serial_debug_unit_40:4C:CA:8C:E9:7C-if00=prog_esp32c3
+usb-FTDI_FT232R_USB_UART_AV74K0PO-if00-port0=com_esp32c3
+usb-Espressif_USB_JTAG_serial_debug_unit_F0:F5:BD:0E:60:58-if00=prog_esp32c6
+usb-FTDI_FT232R_USB_UART_AT4P96AZ-if00-port0=com_esp32c6

--- a/hil/serial-by-function/install_serials_by_function.sh
+++ b/hil/serial-by-function/install_serials_by_function.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sudo ./install_serials_by_function.sh <MAP_FILE> [OUT_DIR]
+
+Arguments:
+  MAP_FILE   Source mapping file (serial_id=function_name)
+  OUT_DIR    Target symlink directory (default: /dev/serial/by-function)
+EOF
+}
+
+[[ "${1:-}" =~ ^(-h|--help)$ ]] && { usage; exit 0; }
+[[ $# -lt 1 || $# -gt 2 ]] && { usage; exit 1; }
+
+if [[ $EUID -ne 0 ]]; then
+  echo "error: run as root (sudo)." >&2
+  exit 1
+fi
+
+MAP_SRC="$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+OUT_DIR="${2:-/dev/serial/by-function}"
+
+if [[ ! -f "$MAP_SRC" ]]; then
+  echo "error: map file not found: $MAP_SRC" >&2
+  exit 1
+fi
+
+# Install locations
+BIN="/usr/local/bin/link_serials_by_function.sh"
+MAP_DST="/etc/serials_map.conf"
+SERVICE="/etc/systemd/system/link-serials-by-function.service"
+RULES="/etc/udev/rules.d/99-link-serials-by-function.rules"
+TMPFILES="/etc/tmpfiles.d/serials-by-function.conf"
+
+# Expect your existing linker script in repo
+if [[ ! -f "scripts/link_serials.sh" ]]; then
+  echo "error: scripts/link_serials.sh not found in current directory." >&2
+  exit 1
+fi
+
+install -m 0755 scripts/link_serials.sh "$BIN"
+install -m 0644 "$MAP_SRC" "$MAP_DST"
+
+cat > "$SERVICE" <<EOF
+[Unit]
+Description=Refresh serial function symlinks
+
+[Service]
+Type=oneshot
+ExecStart=$BIN $MAP_DST $OUT_DIR
+EOF
+
+cat > "$RULES" <<'EOF'
+ACTION=="add|remove", SUBSYSTEM=="tty", KERNEL=="ttyUSB[0-9]*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="link-serials.service"
+ACTION=="add|remove", SUBSYSTEM=="tty", KERNEL=="ttyACM[0-9]*", TAG+="systemd", ENV{SYSTEMD_WANTS}+="link-serials.service"
+EOF
+
+cat > "$TMPFILES" <<EOF
+d $OUT_DIR 0755 root root -
+EOF
+
+systemctl daemon-reload
+udevadm control --reload-rules
+systemd-tmpfiles --create "$TMPFILES"
+
+# Initial run now
+systemctl start link-serials-by-function.service
+
+echo "Installed."
+echo "Map:      $MAP_DST"
+echo "Out dir:  $OUT_DIR"
+echo "Service:  link-serials-by-function.service"

--- a/hil/serial-by-function/scripts/link_serials.sh
+++ b/hil/serial-by-function/scripts/link_serials.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BY_ID_DIR="/dev/serial/by-id"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  link_serials.sh <MAP_FILE> <OUT_DIR>
+
+Arguments:
+  MAP_FILE   Path to mapping file (format: serial_id=function_name)
+  OUT_DIR    Directory where function symlinks will be created
+
+Example:
+  sudo ./scripts/link_serials.sh config/serial_map.conf /dev/serial/by-function
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 1
+fi
+
+MAP_FILE="$1"
+OUT_DIR="$2"
+
+if [[ ! -f "$MAP_FILE" ]]; then
+  echo "error: MAP_FILE not found: $MAP_FILE" >&2
+  exit 1
+fi
+
+# Cleaning condition at the beginning:
+# remove existing symlinks in OUT_DIR so the directory is rebuilt from MAP_FILE
+mkdir -p "$OUT_DIR"
+find "$OUT_DIR" -mindepth 1 -maxdepth 1 -type l -delete
+
+while IFS='=' read -r serial_id function_name; do
+  # skip blanks/comments/invalid lines
+  [[ -z "${serial_id:-}" ]] && continue
+  [[ "${serial_id:0:1}" == "#" ]] && continue
+  [[ -z "${function_name:-}" ]] && continue
+
+  src="$BY_ID_DIR/$serial_id"
+  dst="$OUT_DIR/$function_name"
+
+  if [[ -e "$src" ]]; then
+    ln -sfn "$src" "$dst"
+    echo "linked $dst -> $src"
+  else
+    echo "missing: $src" >&2
+  fi
+done < "$MAP_FILE"

--- a/hil/serial-by-function/uninstall_serials_by_function.sh
+++ b/hil/serial-by-function/uninstall_serials_by_function.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BIN="/usr/local/bin/link_serials_by_function.sh"
+MAP="/etc/serials_map.conf"
+SERVICE="/etc/systemd/system/link-serials-by-function.service"
+RULES="/etc/udev/rules.d/99-link-serials-by-function.rules"
+TMPFILES="/etc/tmpfiles.d/serials-by-function.conf"
+OUT_DIR="/dev/serial/by-function"
+REMOVE_MAP="false"
+
+usage() {
+  cat <<'EOF'
+Usage:
+  sudo ./uninstall_serial_by_function.sh [--out-dir PATH] [--remove-map]
+
+Options:
+  --out-dir PATH   Symlink directory to clean/remove (default: /dev/serial/by-function)
+  --remove-map     Also remove /etc/serials_map.conf
+  -h, --help       Show help
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --out-dir) OUT_DIR="${2:?missing value for --out-dir}"; shift 2 ;;
+    --remove-map) REMOVE_MAP="true"; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown option: $1" >&2; usage; exit 1 ;;
+  esac
+done
+
+if [[ $EUID -ne 0 ]]; then
+  echo "error: run as root (sudo)." >&2
+  exit 1
+fi
+
+# Stop service if present
+if systemctl list-unit-files | grep -q '^link-serials-by-function.service'; then
+  systemctl stop link-serials.service || true
+fi
+
+# Remove installed files
+rm -f "$SERVICE" "$RULES" "$TMPFILES" "$BIN"
+
+if [[ "$REMOVE_MAP" == "true" ]]; then
+  rm -f "$MAP"
+fi
+
+# Clean runtime symlinks and directory
+if [[ -d "$OUT_DIR" ]]; then
+  find "$OUT_DIR" -mindepth 1 -maxdepth 1 -type l -delete || true
+  rmdir "$OUT_DIR" 2>/dev/null || true
+fi
+
+# Reload managers
+systemctl daemon-reload
+udevadm control --reload-rules
+systemd-tmpfiles --remove "$TMPFILES" 2>/dev/null || true
+
+echo "Uninstalled serial by function."


### PR DESCRIPTION
While preparing the hil environment, I noticed that it will save time if we can use an alias to link the serials by function, so later on the details of where a target and its usb-uart adapter are connected are hidden from the test scripts.

I have created a set of config files, scripts and services that will handle giving relevant devices a predictable path every time they are added or removed from the hil-host.

This will work like this:

- a new serial device (/dev/tty*) is plug/unplug
- for every `/dev/serial/by-id/` device
- look for a "function map" in the `serial_map.conf` file
- if the device has a defined value in the config file, create the link `/dev/serial/by-function/device-value`

Having a predictable pattern to address targets and uart adapters make some task trivial. Two examples:

- **reset all devices**: `for device in /dev/serial/by-function/prog_*; do espflash reset -p "$device"; done`
- **erase all devices flash**: `for device in /dev/serial/by-function/prog_*; do espflash erase-flash -p "$device"; done`

As the maintainer has control of the serial map file, the value can be modified to address details of task for different chip families and new functions can be added to adapt to new requirements.

This PR is aligned with the the task defined in the issue #37