### PR TITLE
Fix/tlv unknown arbitrary offset

### DIFF
--- a/ota/src/handler.rs
+++ b/ota/src/handler.rs
@@ -205,13 +205,10 @@ impl<W: OtaActions> UpdateProcessor<W> {
                                     UpdateProcessorState::Error(OtaError::IllegalOperation);
                                 return Err(OtaError::IllegalOperation);
                             }
-                            // Skip this TLV and continue
-                                                            self.tlv_holder.fill(0);
-                                self.current_len = 0;
-                            // self.state = UpdateProcessorState::ReadingParameters {
-                            //     tlv_holder: [0; tlv::MAX_TLV_SIZE as usize],
-                            //     current_len: 0,
-                            // }
+                            // A crafted TLV with an arbitrary length could be used to confuse the UpdateProcessor
+                            // leading to an unknown behaviour. To avoid this, unknown TLVs will thrown an error
+                            return Err(OtaError::UnknownTlvType);
+
                         }
                         Err(WireError::RanOut) => {
                             // Keep current data and wait for more
@@ -390,4 +387,6 @@ pub(crate) enum OtaError {
     WriteError,
     /// Verification of the downloaded firmware failed
     VerificationFailed,
+    /// Unknown TLV Type encountered during processing
+    UnknownTlvType,
 }

--- a/ota/src/handler.rs
+++ b/ota/src/handler.rs
@@ -193,10 +193,6 @@ impl<W: OtaActions> UpdateProcessor<W> {
                             }
                         },
                         Err(WireError::UnknownPacket { number }) => {
-                            warn!(
-                                "UpdateProcessor: Unknown TLV type encountered: {}. Skipping it",
-                                number
-                            );
                             if self.header.ota_type.is_none() {
                                 error!(
                                     "UpdateProcessor: Received unknown TLV type before OTA Type TLV"
@@ -205,6 +201,11 @@ impl<W: OtaActions> UpdateProcessor<W> {
                                     UpdateProcessorState::Error(OtaError::IllegalOperation);
                                 return Err(OtaError::IllegalOperation);
                             }
+                            error!(
+                                "UpdateProcessor: Unknown TLV type encountered: {}",
+                                number
+                            );
+
                             // A crafted TLV with an arbitrary length could be used to confuse the UpdateProcessor
                             // leading to an unknown behaviour. To avoid this, unknown TLVs will thrown an error
                             return Err(OtaError::UnknownTlvType);

--- a/ota/src/sftpserver.rs
+++ b/ota/src/sftpserver.rs
@@ -219,17 +219,39 @@ impl<'a, T: OpaqueFileHandle, W: OtaActions> SftpServer<'a, T> for SftpOtaServer
                 buf.len()
             );
 
-            self.processor
-                .process_data(offset, buf)
-                .await
-                .map_err(|e| {
-                    error!(
-                        "SftpServer Write operation failed during OTA processing: {:?}",
-                        e
-                    );
-                    sunset_sftp::protocol::StatusCode::SSH_FX_FAILURE
-                })?;
-            return Ok(());
+            if let Err(e) = self.processor.process_data(offset, buf).await {
+                match e {
+                    crate::handler::OtaError::IllegalOperation => {
+                        error!(
+                            "SftpServer Write operation failed during OTA processing: Illegal Operation - {:?}",
+                            e
+                        );
+                        return Err(sunset_sftp::protocol::StatusCode::SSH_FX_PERMISSION_DENIED);
+                    }
+                    crate::handler::OtaError::UnknownTlvType => {
+                        error!(
+                            "SftpServer Write operation failed during OTA processing: Unknown TLV Type - {:?}",
+                            e
+                        );
+                        return Err(sunset_sftp::protocol::StatusCode::SSH_FX_OP_UNSUPPORTED);
+                    }
+                    _ => {
+                        error!(
+                            "SftpServer Write operation failed during OTA processing: {:?}",
+                            e
+                        );
+                        return Err(sunset_sftp::protocol::StatusCode::SSH_FX_FAILURE);
+                    }
+                }
+            } else {
+                debug!(
+                    "SftpServer Write operation for OTA processed successfully: handle = {:?}, offset = {:?}, buf_len = {:?}",
+                    opaque_file_handle,
+                    offset,
+                    buf.len()
+                );
+                return Ok(());
+            }
         }
 
         warn!(

--- a/ota/src/tlv.rs
+++ b/ota/src/tlv.rs
@@ -127,7 +127,7 @@ impl<'de> SSHDecode<'de> for Tlv {
             // To handle unknown TLVs, it consumes the announced len
             // and returns an UnknownVariant error
             _ => {
-                warn!("Unknown TLV type encountered: {}. Skipping it", tlv_type);
+                error!("Unknown TLV type encountered: {}", tlv_type);
                 let len = OtaTlvLen::dec(s)?;
                 s.take(len as usize)?; // Skip unknown TLV value
                 Err(sunset::sshwire::WireError::UnknownPacket { number: tlv_type })


### PR DESCRIPTION
This PR is focus on Radically Open Security report on the possible arbitrary offset injection on TLV parameters that may lead to undefined behaviour.

An unknown TLV element in the ota packet now is rejected by the ota handler. The SftpServer response to the Write request in this case is sending back to the client a SSH_FX_OP_UNSUPPORTED status.

This fix blocks the client but does not block the server, that can receive other ssh or sftp connections after the failure.