### PR TITLE
Report hostkey fingerprint on boot

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ cargo run-esp32c6
 ```
 (...)
 INFO - WIFI PSK: <PSK>
-INFO - Connect to the AP `ssh-stamp` as a DHCP client with IP: 192.168.4.1
+INFO - WIFI MAC: <MAC>
+INFO - SSH hostkey fingerprint: <FINGER PRINT>
+INFO - Connect to the AP `<RANDOM AP NAME>` as a DHCP client with IP: 192.168.4.1
 ```
 
 2. Connect a laptop/phone to the `ssh-stamp` AP using the printed PSK, then SSH into the device at `root@192.168.4.1`.

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ cargo run-esp32c6
 (...)
 INFO - WIFI PSK: <PSK>
 INFO - WIFI MAC: <MAC>
-INFO - SSH hostkey fingerprint: <FINGER PRINT>
+INFO - SSH hostkey fingerprint: <FINGERPRINT>
 INFO - Connect to the AP `<RANDOM AP NAME>` as a DHCP client with IP: 192.168.4.1
 ```
 

--- a/src/espressif/net.rs
+++ b/src/espressif/net.rs
@@ -92,6 +92,8 @@ pub async fn if_up(
             mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]
         );
         Efuse::set_mac_address(mac).map_err(|_| sunset::error::BadUsage.build())?;
+
+        print_hostkey_fingerprint(&guard.hostkey);
     }
 
     let ssid_name = wifi_ssid(config).await;
@@ -194,6 +196,21 @@ pub async fn wifi_password(config: &'static SunsetMutex<SSHStampConfig>) -> Stri
             panic!("wifi_pw stored value exceeds 63 characters");
         }),
         None => panic!("wifi_pw must be set before calling wifi_password()"),
+    }
+}
+
+fn print_hostkey_fingerprint(hostkey: &sunset::SignKey) {
+    match hostkey {
+        sunset::SignKey::Ed25519(_) => {
+            let pubkey = hostkey.pubkey();
+            match pubkey.fingerprint(ssh_key::HashAlg::Sha256) {
+                Ok(fp) => info!("SSH hostkey fingerprint: {}", fp),
+                Err(e) => warn!("Failed to compute fingerprint: {:?}", e),
+            }
+        }
+        _ => {
+            warn!("Unsupported key type for fingerprint");
+        }
     }
 }
 


### PR DESCRIPTION
Print the SSH fingerprint in the console and tell the user to match it when connecting to provision.

TODO:
- [ ] Forgot to reflect it in README.md as expected output...

Thx again @ramrunner ;)