### PR TITLE
fix: heap size and env parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-stamp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bcrypt",
  "cfg-if",

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -11,6 +11,10 @@ use crate::config::SSHStampConfig;
 pub mod env_parser {
     use super::String;
 
+    /// Limit the maximum length accepted for an SSH key, Ed25519 lines
+    /// should be less than this.
+    const PUBKEY_MAX_LEN: usize = 256;
+
     /// Sanitizes environment variable input by checking for valid ASCII graphic characters.
     ///
     /// Returns `true` if the input contains at least one character and all characters
@@ -18,6 +22,26 @@ pub mod env_parser {
     #[must_use]
     pub fn env_sanitize(s: &str) -> bool {
         !s.is_empty() && s.bytes().all(|b| b.is_ascii_graphic())
+    }
+
+    /// Validates a public key environment value.
+    ///
+    /// This accepts printable ASCII, including spaces, as the format
+    /// for a key expects `<type> <base64> [comment]`. This would be
+    /// rejected by `env_sanitize` which is stricter, so it is separated
+    /// out here for pubkey environment variables only.
+    #[must_use]
+    pub fn parse_pubkey(value: &str) -> Option<&str> {
+        let trimmed = value.trim();
+
+        if trimmed.is_empty() || trimmed.len() > PUBKEY_MAX_LEN {
+            return None;
+        }
+        if !trimmed.bytes().all(|b| b.is_ascii_graphic() || b == b' ') {
+            return None;
+        }
+
+        Some(trimmed)
     }
 
     #[must_use]
@@ -77,18 +101,25 @@ pub async fn pubkey_env(
     if !config_guard.first_login {
         warn!("SSH_STAMP_PUBKEY env received but not first-login; rejecting");
         a.fail()?;
-    } else if !env_parser::env_sanitize(a.value()?) {
-        warn!("SSH_STAMP_PUBKEY contains invalid characters");
-        a.fail()?;
-    } else if config_guard.add_pubkey(a.value()?).is_ok() {
-        debug!("Added new pubkey from ENV");
-        a.succeed()?;
-        config_guard.first_login = false;
-        *config_changed = true;
-        *auth_checked = true;
     } else {
-        warn!("Failed to add new pubkey from ENV");
-        a.fail()?;
+        match env_parser::parse_pubkey(a.value()?) {
+            None => {
+                warn!("SSH_STAMP_PUBKEY contains invalid characters");
+                a.fail()?;
+            }
+            Some(trimmed) => {
+                if config_guard.add_pubkey(trimmed).is_ok() {
+                    debug!("Added new pubkey from ENV");
+                    a.succeed()?;
+                    config_guard.first_login = false;
+                    *config_changed = true;
+                    *auth_checked = true;
+                } else {
+                    warn!("Failed to add new pubkey from ENV");
+                    a.fail()?;
+                }
+            }
+        }
     }
     Ok(())
 }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -98,10 +98,7 @@ pub async fn pubkey_env(
 ) -> Result<(), sunset::Error> {
     let mut config_guard = config.lock().await;
 
-    if !config_guard.first_login {
-        warn!("SSH_STAMP_PUBKEY env received but not first-login; rejecting");
-        a.fail()?;
-    } else {
+    if config_guard.first_login {
         match env_parser::parse_pubkey(a.value()?) {
             None => {
                 warn!("SSH_STAMP_PUBKEY contains invalid characters");
@@ -120,7 +117,11 @@ pub async fn pubkey_env(
                 }
             }
         }
+    } else {
+        warn!("SSH_STAMP_PUBKEY env received but not first-login; rejecting");
+        a.fail()?;
     }
+
     Ok(())
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -199,6 +199,7 @@ async fn main(spawner: Spawner) -> ! {
         uart_buf,
     };
 
+    #[allow(clippy::large_futures)]
     match peripherals_enabled(peripherals_enabled_struct).await {
         Ok(()) => (),
         Err(e) => {
@@ -233,6 +234,7 @@ async fn peripherals_enabled(s: SshStampInit<'static>) -> Result<(), sunset::Err
         uart_buf: s.uart_buf,
         spawner: s.spawner,
     };
+    #[allow(clippy::large_futures)]
     match wifi_controller_enabled(peripherals_enabled_struct).await {
         Ok(()) => (),
         Err(e) => {
@@ -265,6 +267,7 @@ pub async fn wifi_controller_enabled(s: PeripheralsEnabled<'static>) -> Result<(
         uart_buf: s.uart_buf,
         tcp_stack,
     };
+    #[allow(clippy::large_futures)]
     match tcp_enabled(wifi_controller_enabled_stack).await {
         Ok(()) => (),
         Err(e) => {
@@ -314,6 +317,7 @@ async fn tcp_enabled(s: WifiControllerEnabled<'_>) -> Result<(), sunset::Error> 
             tcp_socket,
             uart_buf: s.uart_buf,
         };
+        #[allow(clippy::large_futures)]
         match socket_enabled(tcp_enabled_struct).await {
             Ok(()) => (),
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,7 +21,6 @@ use ota::otatraits::OtaActions;
 use storage::flash;
 
 extern crate alloc;
-use alloc::boxed::Box;
 
 use sunset_async::{SSHServer, SunsetMutex};
 
@@ -74,7 +73,7 @@ async fn main(spawner: Spawner) -> ! {
             // applying ideas from https://github.com/brainstorm/ssh-stamp/pull/41#issuecomment-2964775170
             esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: 72 * 1024);
         } else {
-                esp_alloc::heap_allocator!(size: 72 * 1024);
+            esp_alloc::heap_allocator!(size: 72 * 1024);
         }
     );
     esp_bootloader_esp_idf::esp_app_desc!();
@@ -200,7 +199,7 @@ async fn main(spawner: Spawner) -> ! {
         uart_buf,
     };
 
-    match Box::pin(peripherals_enabled(peripherals_enabled_struct)).await {
+    match peripherals_enabled(peripherals_enabled_struct).await {
         Ok(()) => (),
         Err(e) => {
             error!("Peripheral error: {e}");
@@ -234,7 +233,7 @@ async fn peripherals_enabled(s: SshStampInit<'static>) -> Result<(), sunset::Err
         uart_buf: s.uart_buf,
         spawner: s.spawner,
     };
-    match Box::pin(wifi_controller_enabled(peripherals_enabled_struct)).await {
+    match wifi_controller_enabled(peripherals_enabled_struct).await {
         Ok(()) => (),
         Err(e) => {
             error!("Wifi controller error: {e}");
@@ -266,7 +265,7 @@ pub async fn wifi_controller_enabled(s: PeripheralsEnabled<'static>) -> Result<(
         uart_buf: s.uart_buf,
         tcp_stack,
     };
-    match Box::pin(tcp_enabled(wifi_controller_enabled_stack)).await {
+    match tcp_enabled(wifi_controller_enabled_stack).await {
         Ok(()) => (),
         Err(e) => {
             error!("AP Stack error: {e}");
@@ -315,7 +314,7 @@ async fn tcp_enabled(s: WifiControllerEnabled<'_>) -> Result<(), sunset::Error> 
             tcp_socket,
             uart_buf: s.uart_buf,
         };
-        match Box::pin(socket_enabled(tcp_enabled_struct)).await {
+        match socket_enabled(tcp_enabled_struct).await {
             Ok(()) => (),
             Err(e) => {
                 error!("TCP socket error: {e}");


### PR DESCRIPTION
### Changes
Two main fixes here:

* When parsing the pubkey from the environment, there needs to be a separate sanitizer that allows spaces, as `ssh_key::PublicKey::from_str` expects `<type> <base64> [comment]` keys.
    * The current `env_sanitize` disallows this, and fails on the `-o SendEnv=SSH_STAMP_PUBKEY` stage.
    * Also I've added a `trim` to remove newlines, which I think is slightly more user-friendly, in case they appear in the env `cat`.
* The code fails to launch on my esp32c6, as it runs out of heap space from the beginning.
    * I measured about 73KiB, which results in an OOM.
    * In the main function I've removed the `Box::pin` on the futures, which saves about 20KiB, so now it's back to running with about 53KiB of heap.