### PR TITLE
HSM Refactor error states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "ssh-stamp"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "bcrypt",
  "cfg-if",

--- a/src/espressif/net.rs
+++ b/src/espressif/net.rs
@@ -149,18 +149,6 @@ pub async fn if_up(
     Ok(ap_stack)
 }
 
-pub fn ap_stack_disable() {
-    // drop ap_stack
-    debug!("AP Stack disabled: WIP");
-    // TODO: Correctly disable/restart AP Stack and/or send messsage to user over SSH
-}
-
-pub fn tcp_socket_disable() {
-    // drop tcp stack
-    debug!("TCP socket disabled: WIP");
-    // TODO: Correctly disable/restart tcp socket and/or send messsage to user over SSH
-}
-
 pub async fn accept_requests<'a>(
     tcp_stack: Stack<'a>,
     rx_buffer: &'a mut [u8],
@@ -178,7 +166,6 @@ pub async fn accept_requests<'a>(
     {
         error!("connect error: {e:?}");
         // continue;
-        tcp_socket_disable();
     }
     debug!("Connected, port 22");
 
@@ -265,16 +252,6 @@ pub async fn wifi_up(
         }
         Timer::after(Duration::from_millis(10)).await;
     }
-}
-
-pub fn wifi_controller_disable() {
-    // TODO: Correctly disable wifi controller
-    // pub async fn wifi_disable(wifi_controller: EspWifiController<'_>) -> (){
-    // drop wifi controller
-    // esp_wifi::deinit_unchecked()
-    // wifi_controller.deinit_unchecked()
-    debug!("Disabling wifi: WIP");
-    //software_reset();
 }
 
 use esp_radio::wifi::{Config, WifiDevice};

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
-use log::{debug, error, warn};
+use log::{debug, error};
 use ssh_stamp::{
     config::SSHStampConfig,
     espressif::{
@@ -36,7 +36,6 @@ use embassy_sync::{blocking_mutex::raw::NoopRawMutex, channel::Channel};
 use esp_hal::interrupt::{Priority, software::SoftwareInterruptControl};
 use esp_hal::peripherals::WIFI;
 use esp_hal::rng::{Rng, TrngSource};
-use esp_hal::system::software_reset;
 
 use esp_println::logger;
 
@@ -50,11 +49,6 @@ cfg_if::cfg_if! {
         use log::info;
         use esp_hal::timer::timg::TimerGroup;
     }
-}
-
-pub fn peripherals_disable() {
-    // drop peripherals
-    debug!("Disabling peripherals: WIP");
 }
 
 pub struct SshStampInit<'a> {
@@ -82,7 +76,7 @@ async fn main(spawner: Spawner) -> ! {
     debug!("HSM: Initialising peripherals ");
 
     // System init
-    let peripherals = esp_hal::init(esp_hal::Config::default());
+    let peripherals = esp_hal::init(esp_hal::Config::default()); // !todo()  panic!("Peripheral initialisation error!"); on peripherial initialsation error
 
     // Enable true random number generation using ADC entropy source before config creation.
     // The ESP32 hardware RNG only produces true random numbers when RF subsystem is enabled
@@ -207,10 +201,7 @@ async fn main(spawner: Spawner) -> ! {
         }
     }
 
-    peripherals_disable();
-    // loop {}
-    warn!("End of Main... Reset!!");
-    software_reset();
+    panic!("End of Main: Peripheral error!");
 }
 
 pub struct PeripheralsEnabled<'a> {
@@ -224,25 +215,27 @@ pub struct PeripheralsEnabled<'a> {
 
 async fn peripherals_enabled(s: SshStampInit<'static>) -> Result<(), sunset::Error> {
     debug!("HSM: peripherals_enabled");
-    let controller = esp_radio::init().map_err(|_| sunset::error::BadUsage.build())?;
+    let controller = esp_radio::init().map_err(|e| panic!("Could not acquire esp_radio: {:?}", e));
 
     let peripherals_enabled_struct = PeripheralsEnabled {
         rng: s.rng,
         wifi: s.wifi,
         config: s.config,
-        controller,
+        controller: controller.unwrap(),
         uart_buf: s.uart_buf,
         spawner: s.spawner,
     };
+
     match Box::pin(wifi_controller_enabled(peripherals_enabled_struct)).await {
-        Ok(()) => (),
+        Ok(_) => {
+            debug!("Disabling wifi");
+            Ok(())
+        }
         Err(e) => {
-            error!("Wifi controller error: {e}");
+            error!("Wifi controller error: {}", e);
+            Result::Err(e)
         }
     }
-
-    net::wifi_controller_disable();
-    Ok(()) // todo!() return relevant value
 }
 
 pub struct WifiControllerEnabled<'a> {
@@ -266,14 +259,17 @@ pub async fn wifi_controller_enabled(s: PeripheralsEnabled<'static>) -> Result<(
         uart_buf: s.uart_buf,
         tcp_stack,
     };
+
     match Box::pin(tcp_enabled(wifi_controller_enabled_stack)).await {
-        Ok(()) => (),
+        Ok(_) => {
+            debug!("AP Stack disabled");
+            Ok(())
+        }
         Err(e) => {
             error!("AP Stack error: {e}");
+            Result::Err(e)
         }
     }
-    net::ap_stack_disable();
-    Ok(()) // todo!() return relevant value
 }
 
 pub struct TCPEnabled<'a> {
@@ -285,7 +281,6 @@ pub struct TCPEnabled<'a> {
 cfg_if::cfg_if!(if #[cfg(feature = "esp32")] {use embassy_net::IpListenEndpoint;});
 async fn tcp_enabled(s: WifiControllerEnabled<'_>) -> Result<(), sunset::Error> {
     debug!("HSM: tcp_enabled");
-
     let mut rx_buffer = [0u8; 1536];
     let mut tx_buffer = [0u8; 1536];
     loop {
@@ -302,7 +297,6 @@ async fn tcp_enabled(s: WifiControllerEnabled<'_>) -> Result<(), sunset::Error> 
                     .await
                 {
                     error!("connect error: {:?}", e);
-                    net::tcp_socket_disable();
                 }
                 debug!("Connected, port 22");
             } else {
@@ -316,14 +310,14 @@ async fn tcp_enabled(s: WifiControllerEnabled<'_>) -> Result<(), sunset::Error> 
             uart_buf: s.uart_buf,
         };
         match Box::pin(socket_enabled(tcp_enabled_struct)).await {
-            Ok(()) => (),
+            Ok(_) => {
+                debug!("TCP socket disabled");
+            }
             Err(e) => {
                 error!("TCP socket error: {e}");
             }
         }
-        net::tcp_socket_disable();
     }
-    // Ok(()) // todo!() return relevant value
 }
 
 pub struct SocketEnabled<'a> {
@@ -335,7 +329,6 @@ pub struct SocketEnabled<'a> {
 
 async fn socket_enabled(s: TCPEnabled<'_>) -> Result<(), sunset::Error> {
     debug!("HSM: socket_enabled");
-    // loop {
     // Spawn network tasks to handle incoming connections with demo_common::session()
     let mut inbuf = [0u8; UART_BUFFER_SIZE];
     let mut outbuf = [0u8; UART_BUFFER_SIZE];
@@ -350,15 +343,15 @@ async fn socket_enabled(s: TCPEnabled<'_>) -> Result<(), sunset::Error> {
         uart_buf: s.uart_buf,
     };
     match ssh_enabled(socket_enabled_struct).await {
-        Ok(()) => (),
+        Ok(_) => {
+            debug!("SSH Server disabled");
+            Ok(())
+        }
         Err(e) => {
-            error!("SSH server error: {e}");
+            error!("SSH server error: {}", e);
+            Result::Err(e)
         }
     }
-
-    serve::ssh_disable();
-    // }
-    Ok(()) // todo!() return relevant value
 }
 
 pub struct SshEnabled<'a, 'b, CL>
@@ -374,9 +367,7 @@ where
 }
 
 async fn ssh_enabled(s: SocketEnabled<'_>) -> Result<(), sunset::Error> {
-    debug!("HSM: ssh_enabled");
-    // loop {
-    debug!("HSM: Starting channel pipe");
+    debug!("HSM: ssh_enabled. Starting channel pipe");
     let chan_pipe = Channel::<NoopRawMutex, serve::SessionType, 1>::new();
     debug!("HSM: Started channel pipe. Calling connection_loop from ssh_enabled");
     let connection = serve::connection_loop(&s.ssh_server, &chan_pipe, s.config);
@@ -391,15 +382,15 @@ async fn ssh_enabled(s: SocketEnabled<'_>) -> Result<(), sunset::Error> {
         connection_loop: connection,
     };
     match client_connected(ssh_enabled_struct).await {
-        Ok(()) => (),
+        Ok(_) => {
+            debug!("Client connection disabled");
+            Ok(())
+        }
         Err(e) => {
-            error!("Client connection error: {e}");
+            error!("Client connection error: {}", e);
+            Result::Err(e)
         }
     }
-
-    serve::connection_disable();
-    // }
-    Ok(()) // todo!() return relevant value
 }
 
 pub struct ClientConnected<'a, 'b, CL, BR>
@@ -430,15 +421,15 @@ where
         tcp_socket: s.tcp_socket,
     };
     match bridge_connected(uart_enabled_struct).await {
-        Ok(()) => (),
+        Ok(_) => {
+            debug!("Bridge disabled");
+            Ok(())
+        }
         Err(e) => {
-            debug!("Bridge error: {e}");
+            debug!("Bridge error: {}", e);
+            Result::Err(e)
         }
     }
-
-    serve::bridge_disable();
-
-    Ok(())
 }
 
 async fn bridge_connected<'a, 'b, CL, BR>(

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,12 +227,12 @@ async fn peripherals_enabled(s: SshStampInit<'static>) -> Result<(), sunset::Err
     };
 
     match Box::pin(wifi_controller_enabled(peripherals_enabled_struct)).await {
-        Ok(_) => {
+        Ok(()) => {
             debug!("Disabling wifi");
             Ok(())
         }
         Err(e) => {
-            error!("Wifi controller error: {}", e);
+            error!("Wifi controller error: {e}");
             Result::Err(e)
         }
     }
@@ -261,7 +261,7 @@ pub async fn wifi_controller_enabled(s: PeripheralsEnabled<'static>) -> Result<(
     };
 
     match Box::pin(tcp_enabled(wifi_controller_enabled_stack)).await {
-        Ok(_) => {
+        Ok(()) => {
             debug!("AP Stack disabled");
             Ok(())
         }
@@ -310,7 +310,7 @@ async fn tcp_enabled(s: WifiControllerEnabled<'_>) -> Result<(), sunset::Error> 
             uart_buf: s.uart_buf,
         };
         match Box::pin(socket_enabled(tcp_enabled_struct)).await {
-            Ok(_) => {
+            Ok(()) => {
                 debug!("TCP socket disabled");
             }
             Err(e) => {
@@ -343,12 +343,12 @@ async fn socket_enabled(s: TCPEnabled<'_>) -> Result<(), sunset::Error> {
         uart_buf: s.uart_buf,
     };
     match ssh_enabled(socket_enabled_struct).await {
-        Ok(_) => {
+        Ok(()) => {
             debug!("SSH Server disabled");
             Ok(())
         }
         Err(e) => {
-            error!("SSH server error: {}", e);
+            error!("SSH server error: {e}");
             Result::Err(e)
         }
     }
@@ -382,12 +382,12 @@ async fn ssh_enabled(s: SocketEnabled<'_>) -> Result<(), sunset::Error> {
         connection_loop: connection,
     };
     match client_connected(ssh_enabled_struct).await {
-        Ok(_) => {
+        Ok(()) => {
             debug!("Client connection disabled");
             Ok(())
         }
         Err(e) => {
-            error!("Client connection error: {}", e);
+            error!("Client connection error: {e}");
             Result::Err(e)
         }
     }
@@ -421,12 +421,12 @@ where
         tcp_socket: s.tcp_socket,
     };
     match bridge_connected(uart_enabled_struct).await {
-        Ok(_) => {
+        Ok(()) => {
             debug!("Bridge disabled");
             Ok(())
         }
         Err(e) => {
-            debug!("Bridge error: {}", e);
+            error!("Bridge error: {e}");
             Result::Err(e)
         }
     }


### PR DESCRIPTION
This PR should tidy up the final pieces for HSM refactor Issue https://github.com/brainstorm/ssh-stamp/issues/25

- We decided that all hardware errors should be handled in the future by the panic handler, rather than software reset which could cause a boot loop.
- All HSM states that initialise hardware and error will cause a panic.
- Once the hardware is initialised, any further HSM states that have errors will restart the tcp socket that is created within an infinite loop.