### PR TITLE
Update dependencies and enable mlkem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "zeroize",
 ]
 
@@ -87,9 +87,9 @@ checksum = "d92bec98840b8f03a5ff5413de5293bfcd8bf96467cf5452609f939ec6f5de16"
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -148,9 +148,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "block-buffer"
@@ -159,6 +159,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -185,9 +194,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cc"
-version = "1.2.62"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -207,7 +216,7 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -216,16 +225,16 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
 ]
@@ -247,6 +256,12 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
 name = "colorchoice"
@@ -280,6 +295,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -297,6 +321,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "ctr"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,15 +340,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.10.7",
  "fiat-crypto",
  "rustc_version",
  "subtle",
@@ -452,9 +495,19 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
- "crypto-common",
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -511,47 +564,47 @@ dependencies = [
 
 [[package]]
 name = "edge-dhcp"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2ccd3a181a33c710e07c3f04623d7a11e9969b1e44a7276ead7873b049720cb"
+checksum = "2e0b32c831ced877a78378312fe0b6f7cdd5759f3ba272578f582ff9bba5291d"
 dependencies = [
  "edge-nal",
  "edge-raw",
  "embassy-futures",
- "embassy-time 0.4.0",
- "heapless 0.8.0",
+ "embassy-time",
+ "heapless 0.9.3",
  "num_enum",
- "rand_core 0.6.4",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
 name = "edge-nal"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac19c3edcdad839c71cb919cd09a632d9915d630760b37f0b74290188c08f248"
+checksum = "f3c7d7163586cb9d457a34561a644aa957ce870226729bf6c9c8beeaead7e0d8"
 dependencies = [
- "embassy-time 0.4.0",
- "embedded-io-async 0.6.1",
+ "embassy-time",
+ "embedded-io-async 0.7.0",
 ]
 
 [[package]]
 name = "edge-nal-embassy"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb09ea0c604bbcb694ecf9cf6596bc5f59bbb5360b68c3e471b61ae9a55a8533"
+checksum = "7f66d0fa7b3b11c25646fae5dc15f3f3830c6127c39743cf2d54ba96110a5330"
 dependencies = [
  "edge-nal",
  "embassy-futures",
  "embassy-net",
- "embedded-io-async 0.6.1",
- "heapless 0.8.0",
+ "embedded-io-async 0.7.0",
+ "heapless 0.9.3",
 ]
 
 [[package]]
 name = "edge-raw"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6207c84e9bc8df8ef3c155196df290f2a51f010bd60c2e78366e51979988bdb5"
+checksum = "466dfce9c2172a4e947b81b556f1f07a86029fbac679e323cfb66c738cc2faea"
 
 [[package]]
 name = "embassy-embedded-hal"
@@ -618,15 +671,15 @@ dependencies = [
 
 [[package]]
 name = "embassy-net"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0558a231a47e7d4a06a28b5278c92e860f1200f24821d2f365a2f40fe3f3c7b2"
+checksum = "71f0aa32082b7df00164f485322d6edab59122c9718b363b07ec23424c2c06a0"
 dependencies = [
  "document-features",
  "embassy-net-driver",
  "embassy-sync 0.7.2",
- "embassy-time 0.5.1",
- "embedded-io-async 0.6.1",
+ "embassy-time",
+ "embedded-io-async 0.7.0",
  "embedded-nal-async",
  "heapless 0.8.0",
  "managed",
@@ -678,23 +731,7 @@ dependencies = [
  "embedded-io-async 0.7.0",
  "futures-core",
  "futures-sink",
- "heapless 0.9.2",
-]
-
-[[package]]
-name = "embassy-time"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f820157f198ada183ad62e0a66f554c610cdcd1a9f27d4b316358103ced7a1f8"
-dependencies = [
- "cfg-if",
- "critical-section",
- "document-features",
- "embassy-time-driver",
- "embedded-hal 0.2.7",
- "embedded-hal 1.0.0",
- "embedded-hal-async",
- "futures-util",
+ "heapless 0.9.3",
 ]
 
 [[package]]
@@ -724,32 +761,35 @@ dependencies = [
 
 [[package]]
 name = "embassy-time-queue-utils"
-version = "0.3.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80e2ee86063bd028a420a5fb5898c18c87a8898026da1d4c852af2c443d0a454"
+checksum = "168297bf80aaf114b3c9ad589bf38b01b3009b9af7f97cd18086c5bbf96f5693"
 dependencies = [
  "embassy-executor-timer-queue",
- "heapless 0.8.0",
+ "heapless 0.9.3",
 ]
 
 [[package]]
 name = "embassy-usb-driver"
-version = "0.2.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17119855ccc2d1f7470a39756b12068454ae27a3eabb037d940b5c03d9c77b7a"
+checksum = "fa675c5f4349b6aa0fcffc4bf9b241f18cd11b97c1f8323273fb9a5449937fbd"
 dependencies = [
  "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
 ]
 
 [[package]]
 name = "embassy-usb-synopsys-otg"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe46f4083109c7ea12a03ca61095d1e87c76fec52c7ca9ee06a42935606dacb"
+checksum = "fb205e26d59e483e8c48f91f637ec217ec7e2cfb0b61d50482301b991b4ff431"
 dependencies = [
  "critical-section",
  "embassy-sync 0.8.0",
+ "embassy-time",
  "embassy-usb-driver",
+ "portable-atomic",
 ]
 
 [[package]]
@@ -827,11 +867,11 @@ dependencies = [
 
 [[package]]
 name = "embedded-nal-async"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76959917cd2b86f40a98c28dd5624eddd1fa69d746241c8257eac428d83cb211"
+checksum = "eb5a1bd585135d302f8f6d7de329310938093da6271b37a6c94b8798795c0c6d"
 dependencies = [
- "embedded-io-async 0.6.1",
+ "embedded-io-async 0.7.0",
  "embedded-nal",
 ]
 
@@ -852,18 +892,18 @@ dependencies = [
 
 [[package]]
 name = "enumset"
-version = "1.1.10"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25b07a8dfbbbfc0064c0a6bdf9edcf966de6b1c33ce344bdeca3b41615452634"
+checksum = "839c4174b41e75c8f7306110b2c51996a293b8d1d850edd529011841d9fede7d"
 dependencies = [
  "enumset_derive",
 ]
 
 [[package]]
 name = "enumset_derive"
-version = "0.14.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f43e744e4ea338060faee68ed933e46e722fb7f3617e722a5772d7e856d8b3ce"
+checksum = "4bd536557b58c682b217b8fb199afdff47cd3eff260623f19e77074eb073d63a"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",
@@ -904,7 +944,7 @@ dependencies = [
  "esp-config",
  "esp-metadata-generated",
  "esp-println",
- "heapless 0.9.2",
+ "heapless 0.9.3",
  "riscv",
  "semihosting",
  "xtensa-lx",
@@ -947,12 +987,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bfcf2a0842903717f4663f6a08512c32b0f6b2d7fb7db3c8a6895d2e6d49f72"
 dependencies = [
  "bitfield",
- "bitflags 2.11.0",
+ "bitflags 2.13.0",
  "bytemuck",
  "cfg-if",
  "critical-section",
  "delegate",
- "digest",
+ "digest 0.10.7",
  "document-features",
  "embassy-embedded-hal",
  "embassy-futures",
@@ -1096,7 +1136,7 @@ dependencies = [
  "esp32c6",
  "esp32s2",
  "esp32s3",
- "heapless 0.9.2",
+ "heapless 0.9.3",
  "instability",
  "log",
  "num-derive",
@@ -1405,9 +1445,9 @@ checksum = "1d758ba1b47b00caf47f24925c0074ecb20d6dfcffe7f6d53395c0465674841a"
 
 [[package]]
 name = "generator"
-version = "0.8.8"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f04ae4152da20c76fe800fa48659201d5cf627c5149ca0b707b69d7eef6cf9"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
 dependencies = [
  "cc",
  "cfg-if",
@@ -1450,9 +1490,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "heapless"
@@ -1466,9 +1506,9 @@ dependencies = [
 
 [[package]]
 name = "heapless"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af2455f757db2b292a9b1768c4b70186d443bcb3b316252d6b540aec1cd89ed"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
 dependencies = [
  "hash32",
  "stable_deref_trait",
@@ -1492,7 +1532,18 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "ctutils",
+ "typenum",
+ "zeroize",
 ]
 
 [[package]]
@@ -1556,9 +1607,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "4603d3033e49e2b0e31229fcab20a5d40089c607d975cd9c80551dc69eed9102"
 dependencies = [
  "jiff-static",
  "log",
@@ -1569,13 +1620,33 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "782d32378dddf207193ac91cefb848ad41abb58195c95168e1291227a0832b47"
 dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "keccak"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e24a010dd405bd7ed803e5253182815b41bf2e6a80cc3bfc066658e03a198aa"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
+name = "kem"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01737161ba802849cfd486b5bd209d38ba4943494c249a8126005170c7621edd"
+dependencies = [
+ "crypto-common 0.2.2",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -1586,15 +1657,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "linked_list_allocator"
-version = "0.10.5"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afa463f5405ee81cdb9cc2baf37e08ec7e4c8209442b5d72c04cfb2cd6e6286"
+checksum = "2b23ac50abb8261cb38c6e2a7192d3302e0836dac1628f6a93b82b4fad185897"
 
 [[package]]
 name = "litrs"
@@ -1604,9 +1675,9 @@ checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "loom"
@@ -1638,9 +1709,35 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "ml-kem"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e15f3e5b957493873e396a66914e83e616b6afe335cdef7efe5c6e1216aba66"
+dependencies = [
+ "hybrid-array",
+ "kem",
+ "module-lattice",
+ "rand_core 0.10.1",
+ "sha3",
+ "zeroize",
+]
+
+[[package]]
+name = "module-lattice"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c61b87c9683ab7cb1c6871d261ad5479b6b10ceb52c4352aaca3b5d35a8febe"
+dependencies = [
+ "ctutils",
+ "hybrid-array",
+ "num-traits",
+ "zeroize",
+]
 
 [[package]]
 name = "nb"
@@ -1785,7 +1882,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -1798,9 +1895,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "091397be61a01d4be58e7841595bd4bfedb15f1cd54977d79b8271e94ed799a3"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -2070,8 +2167,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -2081,8 +2178,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be176f1a57ce4e3d31c1a166222d9768de5954f811601fb7ca06fc8203905ce1"
+dependencies = [
+ "digest 0.11.3",
+ "keccak",
 ]
 
 [[package]]
@@ -2096,9 +2203,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signature"
@@ -2131,7 +2238,16 @@ version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e84b3f4eacbf3a1ce05eac6763b4d629d60cbc94d632e4092c54ade71f1e1a2"
 dependencies = [
- "snafu-derive",
+ "snafu-derive 0.8.9",
+]
+
+[[package]]
+name = "snafu"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1a012328be2e3f5d5f6f3218147ca02588cea4cb865e876849ab6debcf36522"
+dependencies = [
+ "snafu-derive 0.9.1",
 ]
 
 [[package]]
@@ -2139,6 +2255,18 @@ name = "snafu-derive"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1c97747dbf44bb1ca44a561ece23508e99cb592e862f22222dcf42f51d1e451"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "snafu-derive"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f103c50866b8743da9429b8a581d81a27c2d3a9c4ac7df8f8571c1dd7896eda"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -2204,18 +2332,18 @@ version = "0.3.0"
 dependencies = [
  "bcrypt",
  "cfg-if",
- "digest",
+ "digest 0.10.7",
  "ed25519-dalek",
  "embassy-executor",
  "embassy-futures",
  "embassy-net",
  "embassy-sync 0.8.0",
- "embassy-time 0.5.1",
- "embedded-io-async 0.6.1",
+ "embassy-time",
+ "embedded-io-async 0.7.0",
  "embedded-storage",
  "embedded-storage-async",
  "getrandom",
- "heapless 0.8.0",
+ "heapless 0.9.3",
  "hex",
  "hmac",
  "log",
@@ -2226,7 +2354,7 @@ dependencies = [
  "rustc-hash",
  "sha2",
  "smoltcp",
- "snafu",
+ "snafu 0.8.9",
  "ssh-key",
  "ssh-stamp-hal",
  "subtle",
@@ -2248,7 +2376,7 @@ dependencies = [
  "embassy-futures",
  "embassy-net",
  "embassy-sync 0.8.0",
- "embassy-time 0.5.1",
+ "embassy-time",
  "embedded-storage",
  "embedded-storage-async",
  "esp-alloc",
@@ -2260,7 +2388,7 @@ dependencies = [
  "esp-rtos",
  "esp-storage",
  "getrandom",
- "heapless 0.8.0",
+ "heapless 0.9.3",
  "hmac",
  "log",
  "once_cell",
@@ -2279,7 +2407,7 @@ version = "0.2.0"
 dependencies = [
  "embassy-net",
  "embassy-sync 0.8.0",
- "heapless 0.8.0",
+ "heapless 0.9.3",
 ]
 
 [[package]]
@@ -2333,7 +2461,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sunset"
 version = "0.4.0"
-source = "git+https://github.com/jubeormk1/sunset?branch=dev%2Fsftp-basic#45f54ff2d58b81847643dd45be9dda0cc56ffa12"
+source = "git+https://github.com/mkj/sunset?rev=f6722357a5e7d047336e8d2089b5b2853b45fb9d#f6722357a5e7d047336e8d2089b5b2853b45fb9d"
 dependencies = [
  "aes",
  "ascii",
@@ -2341,19 +2469,18 @@ dependencies = [
  "cipher",
  "ctr",
  "curve25519-dalek",
- "digest",
+ "digest 0.10.7",
  "ed25519-dalek",
- "embedded-io 0.6.1",
+ "embedded-io 0.7.1",
  "getrandom",
- "heapless 0.8.0",
+ "heapless 0.9.3",
  "hmac",
  "log",
+ "ml-kem",
  "poly1305",
- "pretty-hex",
  "rand_core 0.6.4",
  "sha2",
- "signature",
- "snafu",
+ "snafu 0.9.1",
  "ssh-key",
  "subtle",
  "sunset-sshwire-derive",
@@ -2364,11 +2491,11 @@ dependencies = [
 [[package]]
 name = "sunset-async"
 version = "0.4.0"
-source = "git+https://github.com/jubeormk1/sunset?branch=dev%2Fsftp-basic#45f54ff2d58b81847643dd45be9dda0cc56ffa12"
+source = "git+https://github.com/mkj/sunset?rev=f6722357a5e7d047336e8d2089b5b2853b45fb9d#f6722357a5e7d047336e8d2089b5b2853b45fb9d"
 dependencies = [
  "embassy-futures",
- "embassy-sync 0.7.2",
- "embedded-io-async 0.6.1",
+ "embassy-sync 0.8.0",
+ "embedded-io-async 0.7.0",
  "log",
  "portable-atomic",
  "sunset",
@@ -2377,11 +2504,11 @@ dependencies = [
 [[package]]
 name = "sunset-sftp"
 version = "0.1.2"
-source = "git+https://github.com/jubeormk1/sunset?branch=dev%2Fsftp-basic#45f54ff2d58b81847643dd45be9dda0cc56ffa12"
+source = "git+https://github.com/mkj/sunset?rev=f6722357a5e7d047336e8d2089b5b2853b45fb9d#f6722357a5e7d047336e8d2089b5b2853b45fb9d"
 dependencies = [
  "embassy-futures",
- "embassy-sync 0.7.2",
- "embedded-io-async 0.6.1",
+ "embassy-sync 0.8.0",
+ "embedded-io-async 0.7.0",
  "log",
  "num_enum",
  "paste",
@@ -2393,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "sunset-sshwire-derive"
 version = "0.2.1"
-source = "git+https://github.com/jubeormk1/sunset?branch=dev%2Fsftp-basic#45f54ff2d58b81847643dd45be9dda0cc56ffa12"
+source = "git+https://github.com/mkj/sunset?rev=f6722357a5e7d047336e8d2089b5b2853b45fb9d#f6722357a5e7d047336e8d2089b5b2853b45fb9d"
 dependencies = [
  "virtue",
 ]
@@ -2462,9 +2589,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime",
@@ -2544,9 +2671,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "ufmt-write"
@@ -2572,7 +2699,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -2669,9 +2796,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1996,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.10"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "riscv"
@@ -2461,7 +2461,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "sunset"
 version = "0.4.0"
-source = "git+https://github.com/mkj/sunset?rev=f6722357a5e7d047336e8d2089b5b2853b45fb9d#f6722357a5e7d047336e8d2089b5b2853b45fb9d"
+source = "git+https://github.com/mkj/sunset?rev=fd3f8284ebca704f3c3789faf80487af18a50114#fd3f8284ebca704f3c3789faf80487af18a50114"
 dependencies = [
  "aes",
  "ascii",
@@ -2491,7 +2491,7 @@ dependencies = [
 [[package]]
 name = "sunset-async"
 version = "0.4.0"
-source = "git+https://github.com/mkj/sunset?rev=f6722357a5e7d047336e8d2089b5b2853b45fb9d#f6722357a5e7d047336e8d2089b5b2853b45fb9d"
+source = "git+https://github.com/mkj/sunset?rev=fd3f8284ebca704f3c3789faf80487af18a50114#fd3f8284ebca704f3c3789faf80487af18a50114"
 dependencies = [
  "embassy-futures",
  "embassy-sync 0.8.0",
@@ -2504,7 +2504,7 @@ dependencies = [
 [[package]]
 name = "sunset-sftp"
 version = "0.1.2"
-source = "git+https://github.com/mkj/sunset?rev=f6722357a5e7d047336e8d2089b5b2853b45fb9d#f6722357a5e7d047336e8d2089b5b2853b45fb9d"
+source = "git+https://github.com/mkj/sunset?rev=fd3f8284ebca704f3c3789faf80487af18a50114#fd3f8284ebca704f3c3789faf80487af18a50114"
 dependencies = [
  "embassy-futures",
  "embassy-sync 0.8.0",
@@ -2520,7 +2520,7 @@ dependencies = [
 [[package]]
 name = "sunset-sshwire-derive"
 version = "0.2.1"
-source = "git+https://github.com/mkj/sunset?rev=f6722357a5e7d047336e8d2089b5b2853b45fb9d#f6722357a5e7d047336e8d2089b5b2853b45fb9d"
+source = "git+https://github.com/mkj/sunset?rev=fd3f8284ebca704f3c3789faf80487af18a50114#fd3f8284ebca704f3c3789faf80487af18a50114"
 dependencies = [
  "virtue",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ authors = [
     "Julio Beltran Ortega <jubeormk1@gmail.com>",
     "Anthony Tambasco <anthony.tambasco@fastmail.com>",
     "Roman Valls Guimera <brainstorm@nopcode.org>",
+    "Marko Malenic <mmalenic1@gmail.com>",
 ]
 edition = "2024"
 license = "GPL-3.0-or-later"
@@ -35,21 +36,21 @@ embassy-time = { version = "0.5" }
 embassy-futures = "0.1.2"
 
 # Collections
-heapless = "0.8"
+heapless = "0.9"
 
 # ESP32
 esp-hal = { version = "1.1", features = ["unstable", "log-04"] }
 
 # SSH protocol
-sunset = { git = "https://github.com/jubeormk1/sunset", branch = "dev/sftp-basic", default-features = false, features = [
+sunset = { git = "https://github.com/mkj/sunset", rev = "f6722357a5e7d047336e8d2089b5b2853b45fb9d", default-features = false, features = [
     "openssh-key",
     "embedded-io",
 ] }
-sunset-async = { git = "https://github.com/jubeormk1/sunset", branch = "dev/sftp-basic", default-features = false, features = [
+sunset-async = { git = "https://github.com/mkj/sunset", rev = "f6722357a5e7d047336e8d2089b5b2853b45fb9d", default-features = false, features = [
     "multi-thread",
 ] }
-sunset-sshwire-derive = { git = "https://github.com/jubeormk1/sunset", branch = "dev/sftp-basic", default-features = false }
-sunset-sftp = { git = "https://github.com/jubeormk1/sunset", branch = "dev/sftp-basic", default-features = false }
+sunset-sshwire-derive = { git = "https://github.com/mkj/sunset", rev = "f6722357a5e7d047336e8d2089b5b2853b45fb9d", default-features = false }
+sunset-sftp = { git = "https://github.com/mkj/sunset", rev = "f6722357a5e7d047336e8d2089b5b2853b45fb9d", default-features = false }
 
 # Crypto
 sha2 = { version = "0.10", default-features = false }
@@ -69,10 +70,10 @@ esp-storage = { version = "0.8" }
 esp-bootloader-esp-idf = { version = "0.4.0" }
 
 # Networking
-edge-dhcp = "0.6"
-edge-nal = "0.5"
-edge-nal-embassy = "0.7"
-embassy-net = { version = "0.7", features = [
+edge-dhcp = "0.7"
+edge-nal = "0.6"
+edge-nal-embassy = "0.8"
+embassy-net = { version = "0.8", features = [
     "tcp",
     "udp",
     "dhcpv4",
@@ -93,7 +94,7 @@ portable-atomic = "1"
 snafu = { version = "0.8", default-features = false }
 pastey = "0.1"
 pretty-hex = { version = "0.4", default-features = false }
-embedded-io-async = "0.6.1"
+embedded-io-async = "0.7"
 embassy-embedded-hal = "0.6"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,15 +42,15 @@ heapless = "0.9"
 esp-hal = { version = "1.1", features = ["unstable", "log-04"] }
 
 # SSH protocol
-sunset = { git = "https://github.com/mkj/sunset", rev = "f6722357a5e7d047336e8d2089b5b2853b45fb9d", default-features = false, features = [
+sunset = { git = "https://github.com/mkj/sunset", rev = "fd3f8284ebca704f3c3789faf80487af18a50114", default-features = false, features = [
     "openssh-key",
     "embedded-io",
 ] }
-sunset-async = { git = "https://github.com/mkj/sunset", rev = "f6722357a5e7d047336e8d2089b5b2853b45fb9d", default-features = false, features = [
+sunset-async = { git = "https://github.com/mkj/sunset", rev = "fd3f8284ebca704f3c3789faf80487af18a50114", default-features = false, features = [
     "multi-thread",
 ] }
-sunset-sshwire-derive = { git = "https://github.com/mkj/sunset", rev = "f6722357a5e7d047336e8d2089b5b2853b45fb9d", default-features = false }
-sunset-sftp = { git = "https://github.com/mkj/sunset", rev = "f6722357a5e7d047336e8d2089b5b2853b45fb9d", default-features = false }
+sunset-sshwire-derive = { git = "https://github.com/mkj/sunset", rev = "fd3f8284ebca704f3c3789faf80487af18a50114", default-features = false }
+sunset-sftp = { git = "https://github.com/mkj/sunset", rev = "fd3f8284ebca704f3c3789faf80487af18a50114", default-features = false }
 
 # Crypto
 sha2 = { version = "0.10", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,8 +22,9 @@ members = ["ssh-stamp-hal", "ssh-stamp-esp32", "ota"]
 [workspace.lints.clippy]
 mem_forget = "warn"
 await_holding_lock = "warn"
-large_futures = "warn"
 pedantic = "warn"
+large_futures = { level = "allow", priority = 1 }
+default_trait_access = { level = "allow", priority = 1 }
 
 [lints]
 workspace = true

--- a/ota/src/sftpserver.rs
+++ b/ota/src/sftpserver.rs
@@ -12,9 +12,9 @@ use sunset::sshwire::{BinString, WireError};
 use sunset_async::ChanInOut;
 use sunset_sftp::{
     SftpHandler,
-    handles::{InitWithSeed, OpaqueFileHandle},
+    handles::OpaqueFileHandle,
     protocol::{FileHandle, Filename, NameEntry, PFlags, StatusCode},
-    server::{MAX_REQUEST_LEN, SftpServer},
+    server::{DirReadHeaderReply, DirReadReplyFinished, MAX_REQUEST_LEN, SftpServer},
 };
 
 use log::{debug, error, info, warn};
@@ -33,11 +33,13 @@ pub async fn run_ota_server<W: OtaActions>(
 
     let mut file_server = SftpOtaServer::new(ota_writer);
 
+    let (chan_in, chan_out) = stdio.split();
+
     match SftpHandler::<OtaOpaqueFileHandle, SftpOtaServer<OtaOpaqueFileHandle, W>, 512>::new(
         &mut file_server,
         &mut request_buffer,
     )
-    .process_loop(stdio, &mut buffer_in)
+    .process_loop(chan_in, chan_out, &mut buffer_in)
     .await
     {
         Ok(()) => {
@@ -86,10 +88,17 @@ impl OpaqueFileHandle for OtaOpaqueFileHandle {
     }
 }
 
-impl InitWithSeed for OtaOpaqueFileHandle {
+/// Derive the file handle from a path seed.
+trait InitFromSeed: Sized {
+    type Err;
+
+    fn init_from_seed(seed: &str) -> Result<Self, Self::Err>;
+}
+
+impl InitFromSeed for OtaOpaqueFileHandle {
     type Err = WireError;
 
-    fn init_with_seed(seed: &str) -> Result<Self, Self::Err> {
+    fn init_from_seed(seed: &str) -> Result<Self, Self::Err> {
         let mut hasher = FxHasher::default();
         hasher.write(seed.as_bytes());
         let hash_bytes = u32::try_from(hasher.finish()).unwrap_or(0).to_be_bytes();
@@ -121,7 +130,7 @@ impl<T, W: OtaActions> SftpOtaServer<T, W> {
     }
 }
 
-impl<T: OpaqueFileHandle + InitWithSeed, W: OtaActions> SftpServer<'_, T> for SftpOtaServer<T, W> {
+impl<T: OpaqueFileHandle + InitFromSeed, W: OtaActions> SftpServer<T> for SftpOtaServer<T, W> {
     async fn open(&'_ mut self, path: &str, mode: &PFlags) -> sunset_sftp::server::SftpOpResult<T> {
         if self.file_handle.is_none() {
             let num_mode = u32::from(mode);
@@ -130,7 +139,7 @@ impl<T: OpaqueFileHandle + InitWithSeed, W: OtaActions> SftpServer<'_, T> for Sf
                 || num_mode & u32::from(&PFlags::SSH_FXF_APPEND) > 0
                 || num_mode & u32::from(&PFlags::SSH_FXF_CREAT) > 0;
 
-            let handle = T::init_with_seed(path).map_err(|_| StatusCode::SSH_FX_FAILURE)?;
+            let handle = T::init_from_seed(path).map_err(|_| StatusCode::SSH_FX_FAILURE)?;
             self.file_handle = Some(handle.clone());
             info!(
                 "SftpServer Open operation: path = {:?}, write_permission = {:?}, handle = {:?}",
@@ -175,21 +184,6 @@ impl<T: OpaqueFileHandle + InitWithSeed, W: OtaActions> SftpServer<'_, T> for Sf
             warn!("SftpServer Close operation granted on untracked handle: {handle:?}");
             Ok(())
         }
-    }
-
-    async fn read<const N: usize>(
-        &mut self,
-        opaque_file_handle: &T,
-        offset: u64,
-        len: u32,
-        _reply: &mut sunset_sftp::server::ReadReply<'_, N>,
-    ) -> sunset_sftp::error::SftpResult<()> {
-        error!(
-            "SftpServer Read operation not defined: handle = {opaque_file_handle:?}, offset = {offset:?}, len = {len:?}"
-        );
-        Err(sunset_sftp::error::SftpError::FileServerError(
-            StatusCode::SSH_FX_OP_UNSUPPORTED,
-        ))
     }
 
     async fn write(
@@ -244,7 +238,7 @@ impl<T: OpaqueFileHandle + InitWithSeed, W: OtaActions> SftpServer<'_, T> for Sf
     }
 
     async fn opendir(&mut self, dir: &str) -> sunset_sftp::server::SftpOpResult<T> {
-        let handle = T::init_with_seed(dir).map_err(|_| StatusCode::SSH_FX_FAILURE)?;
+        let handle = T::init_from_seed(dir).map_err(|_| StatusCode::SSH_FX_FAILURE)?;
         info!("SftpServer OpenDir: dir = {dir:?}. Returning {handle:?}");
         Ok(handle)
     }
@@ -252,8 +246,8 @@ impl<T: OpaqueFileHandle + InitWithSeed, W: OtaActions> SftpServer<'_, T> for Sf
     async fn readdir<const N: usize>(
         &mut self,
         opaque_dir_handle: &T,
-        _reply: &mut sunset_sftp::server::DirReply<'_, N>,
-    ) -> sunset_sftp::server::SftpOpResult<()> {
+        _reply: DirReadHeaderReply<'_, N>,
+    ) -> sunset_sftp::server::SftpOpResult<DirReadReplyFinished> {
         info!("SftpServer ReadDir called for OTA SFTP server on handle: {opaque_dir_handle:?}");
         Err(StatusCode::SSH_FX_EOF)
     }
@@ -265,17 +259,5 @@ impl<T: OpaqueFileHandle + InitWithSeed, W: OtaActions> SftpServer<'_, T> for Sf
             _longname: Filename::from("/"),
             attrs: sunset_sftp::protocol::Attrs::default(),
         })
-    }
-
-    async fn attrs(
-        &mut self,
-        follow_links: bool,
-        file_path: &str,
-    ) -> sunset_sftp::server::SftpOpResult<sunset_sftp::protocol::Attrs> {
-        error!(
-            "SftpServer Stats operation not defined: follow_link = {follow_links:?}, \
-            file_path = {file_path:?}"
-        );
-        Err(StatusCode::SSH_FX_OP_UNSUPPORTED)
     }
 }

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,7 +138,7 @@ where
 
 fn generate_wifi_password() -> Result<String<63>, sunset::Error> {
     let mut rnd = [0u8; 24];
-    sunset::random::fill_random(&mut rnd)?;
+    getrandom::getrandom(&mut rnd).map_err(|_| sunset::Error::msg("RNG failed"))?;
     let mut pw = String::<63>::new();
     for &byte in &rnd {
         let _ = pw.push(WIFI_PASSWORD_CHARS[(byte as usize) % 62] as char);

--- a/src/config.rs
+++ b/src/config.rs
@@ -129,7 +129,7 @@ impl SSHStampConfig {
 
     pub(crate) fn generate_wifi_ssid() -> Result<String<32>> {
         let mut rnd = [0u8; 16];
-        sunset::random::fill_random(&mut rnd)?;
+        getrandom::getrandom(&mut rnd).map_err(|_| sunset::Error::msg("RNG failed"))?;
         let mut ssid = String::<32>::new();
         for &byte in &rnd {
             let _ = ssid.push(WIFI_PASSWORD_CHARS[(byte as usize) % 62] as char);
@@ -139,7 +139,7 @@ impl SSHStampConfig {
 
     pub(crate) fn generate_wifi_password() -> Result<String<63>> {
         let mut rnd = [0u8; 24];
-        sunset::random::fill_random(&mut rnd)?;
+        getrandom::getrandom(&mut rnd).map_err(|_| sunset::Error::msg("RNG failed"))?;
         let mut pw = String::<63>::new();
         for &byte in &rnd {
             let _ = pw.push(WIFI_PASSWORD_CHARS[(byte as usize) % 62] as char);
@@ -188,7 +188,7 @@ impl SSHStampConfig {
 
 fn random_mac() -> Result<[u8; 6]> {
     let mut mac = [0u8; 6];
-    sunset::random::fill_random(&mut mac)?;
+    getrandom::getrandom(&mut mac).map_err(|_| sunset::Error::msg("RNG failed"))?;
     // unicast, locally administered
     mac[0] = (mac[0] & 0xfc) | 0x02;
     Ok(mac)
@@ -245,9 +245,9 @@ fn enc_ipv4_config(v: Option<&StaticConfigV4>, s: &mut dyn SSHSink) -> WireResul
 fn enc_ipv6_config(v: Option<&StaticConfigV6>, s: &mut dyn SSHSink) -> WireResult<()> {
     v.is_some().enc(s)?;
     if let Some(v) = v {
-        v.address.address().to_bits().enc(s)?;
+        v.address.address().octets().enc(s)?;
         v.address.prefix_len().enc(s)?;
-        let gw = v.gateway.as_ref().map(|g| g.to_bits());
+        let gw = v.gateway.as_ref().map(core::net::Ipv6Addr::octets);
         enc_option(gw.as_ref(), s)?;
     }
     Ok(())
@@ -271,7 +271,7 @@ where
         Ok(StaticConfigV4 {
             address: Ipv4Cidr::new(ad, prefix),
             gateway,
-            dns_servers: heapless::Vec::new(),
+            dns_servers: Default::default(),
         })
     })
     .transpose()
@@ -284,15 +284,15 @@ where
 {
     let opt = bool::dec(s)?;
     opt.then(|| {
-        let ad: u128 = SSHDecode::dec(s)?;
-        let ad = Ipv6Addr::from_bits(ad);
+        let ad: [u8; 16] = SSHDecode::dec(s)?;
+        let ad = Ipv6Addr::from(ad);
         let prefix = SSHDecode::dec(s)?;
         if prefix > 32 {
             // embassy panics, so test it here
             return Err(WireError::PacketWrong);
         }
-        let gw: Option<u128> = dec_option(s)?;
-        let gateway = gw.map(|gw| Ipv6Addr::from_bits(gw));
+        let gw: Option<[u8; 16]> = dec_option(s)?;
+        let gateway = gw.map(Ipv6Addr::from);
         Ok(StaticConfigV6 {
             address: Ipv6Cidr::new(ad, prefix),
             gateway,
@@ -341,8 +341,10 @@ impl<'de> SSHDecode<'de> for SSHStampConfig {
             *k = dec_option(s)?;
         }
 
-        let wifi_ssid = SSHDecode::dec(s)?;
-        let wifi_pw = SSHDecode::dec(s)?;
+        let wifi_ssid_str: &str = SSHDecode::dec(s)?;
+        let wifi_ssid = String::try_from(wifi_ssid_str).map_err(|_| WireError::BadString)?;
+        let wifi_pw_str: &str = SSHDecode::dec(s)?;
+        let wifi_pw = String::try_from(wifi_pw_str).map_err(|_| WireError::BadString)?;
 
         let mac = SSHDecode::dec(s)?;
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,6 +271,8 @@ where
         Ok(StaticConfigV4 {
             address: Ipv4Cidr::new(ad, prefix),
             gateway,
+            // The embassy-net heapless version is different so `Default::default()` must be
+            // used here.
             dns_servers: Default::default(),
         })
     })

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -93,6 +93,7 @@ pub async fn connection_loop<P: PlatformServices>(
             ServEvent::Defunct => {
                 defunct()?;
             }
+            ServEvent::Authenticated => {}
             ServEvent::PollAgain => {}
         }
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -93,8 +93,7 @@ pub async fn connection_loop<P: PlatformServices>(
             ServEvent::Defunct => {
                 defunct()?;
             }
-            ServEvent::Authenticated => {}
-            ServEvent::PollAgain => {}
+            ServEvent::Authenticated | ServEvent::PollAgain => {}
         }
     }
 }

--- a/ssh-stamp-esp32/src/network/wifi.rs
+++ b/ssh-stamp-esp32/src/network/wifi.rs
@@ -112,7 +112,7 @@ impl NetworkProviderHal for EspWifi {
         let net_config = embassy_net::Config::ipv4_static(StaticConfigV4 {
             address: Ipv4Cidr::new(self.gateway, 24),
             gateway: Some(self.gateway),
-            dns_servers: heapless::Vec::new(),
+            dns_servers: Default::default(),
         });
 
         let seed = u64::from(self.rng.random()) << 32 | u64::from(self.rng.random());


### PR DESCRIPTION
Related to https://github.com/brainstorm/ssh-stamp/issues/34

### Changes
* Updates sunset to the latest main commit on the upstream repo. This enables mlkem by default (although it is explicitly enabled here as well).
* Some other dependencies required updating because of this, e.g. embassy-net, embassy-io, edge, and heapless.