### PR TITLE
Reject OTA images built for a different chip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,6 +2021,7 @@ name = "ota"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "heapless 0.9.3",
  "log",
  "sha2 0.10.9",
  "ssh-stamp-hal",

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The SSH connection can be established via WiFi, enabling untethered (and secure)
 
 ## Using
 
-Refer to [building](./docs/BUILDING.md) if you are not using our binary releases and [using](./docs/USING.md) documentation.
+Refer to [building](./docs/BUILDING.md) if you are not using our binary releases and [using](./docs/USING.md) documentation. Once a device is up, it can update itself [over SFTP](./docs/OTA.md).
 
 ## Targets
 

--- a/docs/OTA.md
+++ b/docs/OTA.md
@@ -1,0 +1,119 @@
+<!--
+SPDX-FileCopyrightText: 2026 Roman Valls Guimera <brainstorm@nopcode.org>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+## Firmware updates over SFTP
+
+Devices built with the `sftp-ota` feature accept a new firmware image over the
+SSH connection they already serve. There is no separate update port, protocol
+or bootloader shell: the image is written with a plain `sftp` client.
+
+### Packing an image
+
+The device does not accept a raw binary. It expects an `.ota` file, which is
+the binary prefixed with a short TLV header describing it. `packer` produces
+one:
+
+```
+cargo packer -- --target esp32c6 target/riscv32imac-unknown-none-elf/release/ssh-stamp-esp32.bin
+```
+
+This writes `ssh-stamp-esp32.ota` next to the input. `--target` records the
+chip the image was built for; see [Target checking](#target-checking) below.
+`packer --unpack` reverses the process and verifies the recorded checksum,
+which is a quick way to inspect an image you did not build yourself.
+
+### Uploading
+
+```
+sftp root@192.168.4.1
+> put ssh-stamp-esp32.ota
+```
+
+The device streams the upload straight into the inactive OTA partition,
+hashing as it goes. When the last byte arrives it compares the hash against
+the checksum in the header; only on a match does it mark the partition
+bootable and reset into the new image. A transfer that is interrupted,
+truncated or corrupted leaves the running firmware untouched, because the
+partition is never marked bootable.
+
+The SFTP subsystem is exclusive: while an upload is in progress the device
+will not also serve a shell or a bridge session.
+
+### Target checking
+
+A firmware image for the wrong chip is not merely useless, it is a brick
+waiting to happen. Since the image carries no chip identity of its own, the
+packer records one for it.
+
+`packer --target <chip>` adds a `TargetChip` TLV holding the chip name exactly
+as `esp_hal::chip!()` spells it — `esp32c6`, `esp32s3`, and so on. The record
+is written immediately after the OTA type, so it lands within the first ~15
+bytes of the transfer. A device that reads a name other than its own aborts
+the write there and then with `SSH_FX_OP_UNSUPPORTED`; the client reports a
+failed `put` after a few bytes instead of after a full upload.
+
+`--target` is optional. An image packed without it has no `TargetChip` record,
+cannot be screened, and is accepted with a warning on the device console —
+which is what keeps images packed before this record existed working. Passing
+the flag is strongly recommended; omitting it trades away the only cheap
+protection against flashing the wrong chip.
+
+Note the compatibility direction: an image packed **with** `--target` is
+rejected by firmware predating the `TargetChip` record, because that firmware
+treats any unrecognised TLV as fatal. Update the device first over USB, or
+pack without `--target`, when crossing that boundary.
+
+### Header format
+
+The header is a sequence of type-length-value records, each with a one-byte
+type and a one-byte length:
+
+| Type | Name             | Length | Value                                        |
+| ---- | ---------------- | ------ | -------------------------------------------- |
+| 0    | `OtaType`        | 4      | `0x73736873` (`sshs`). **Must come first**   |
+| 3    | `TargetChip`     | 1–16   | Chip name, UTF-8. Optional; should come second |
+| 2    | `Sha256Checksum` | 32     | SHA-256 of the firmware blob                 |
+| 1    | `FirmwareBlob`   | 4      | Blob length in bytes. **Must come last**     |
+
+The firmware blob follows the `FirmwareBlob` record immediately; anything
+after that point is blob, not header.
+
+Ordering is enforced, not conventional. `OtaType` first means a file that is
+not an ssh-stamp image is rejected on its first four bytes. `FirmwareBlob`
+last means the device knows the size and the expected hash before it commits
+a single byte to flash.
+
+An unrecognised type is fatal: the device rejects the image rather than
+skipping the record. That is deliberate. A parser that ignores what it does
+not understand will happily accept a header assembled to mean one thing to the
+packer and another to the device, and [Radically Open Security's audit of this
+code](https://github.com/brainstorm/ssh-stamp/issues/76) flagged exactly that
+shape. Forward compatibility, if it is wanted later, needs an explicit
+mechanism — a critical/non-critical split in the type space, so that skipping
+is a property the format grants a record rather than a default the parser
+applies to everything — and not a silent `continue`.
+
+### Target support
+
+`sftp-ota` builds for every board below. "Verified on hardware" means an image
+has actually been uploaded to the board and booted:
+
+| Board                                | Chip    | Builds | Verified on hardware |
+| ------------------------------------ | ------- | ------ | -------------------- |
+| esp32c6-devkitc                      | esp32c6 | yes    | yes                  |
+| esp32c6-generic                      | esp32c6 | yes    | no                   |
+| esp32c5-devkitc                      | esp32c5 | yes    | no                   |
+| esp32c61-devkitc                     | esp32c61| yes    | no                   |
+| esp32-s2-saola                       | esp32s2 | yes    | no                   |
+| waveshare-esp32-s3-touch-lcd-43      | esp32s3 | yes    | no                   |
+
+Chips with an IC feature but no board definition (`esp32`, `esp32c2`,
+`esp32c3`, `esp32s3` bare) build as a library only and have no OTA path to
+exercise until a board is added.
+
+Building is a weak claim: it says the OTA partition layout and flash driver
+compile for the chip, not that the bootloader accepts what this code writes.
+Treat anything in the last column marked "no" as untested.

--- a/ota/Cargo.toml
+++ b/ota/Cargo.toml
@@ -17,6 +17,7 @@ sunset.workspace = true
 sunset-async.workspace = true
 sunset-sftp.workspace = true
 
+heapless.workspace = true
 log.workspace = true
 sha2.workspace = true
 

--- a/ota/src/bin/packer.rs
+++ b/ota/src/bin/packer.rs
@@ -24,6 +24,7 @@ const WRITE_FAILED: i32 = 7;
 const SEEK_FAILED: i32 = 8;
 const CHECKSUM_MISMATCH: i32 = 9;
 const FILE_TOO_LARGE: i32 = 10;
+const BAD_TARGET: i32 = 11;
 
 fn main() {
     let matches = Command::new("packer")
@@ -37,6 +38,11 @@ fn main() {
         .arg(
             clap::arg!(-p --pack "(default) Packs a binary file as an OTA file. Will save to <file>.ota")
                 .action(ArgAction::SetTrue)
+                .conflicts_with("unpack"),
+        )
+        .arg(
+            clap::arg!(-t --target <CHIP> "Chip the firmware was built for, e.g. esp32c6. Lets the device refuse a mismatched image on the first bytes of the transfer instead of after the whole upload")
+                .required(false)
                 .conflicts_with("unpack"),
         )
         .get_matches();
@@ -62,7 +68,18 @@ fn main() {
         std::process::exit(unpack_ota(file_path));
     }
 
-    std::process::exit(pack_bin(file_path));
+    let target_chip = matches.get_one::<String>("target").map(String::as_str);
+    if let Some(chip) = target_chip
+        && (chip.is_empty() || chip.len() > tlv::MAX_TARGET_CHIP_LEN)
+    {
+        eprintln!(
+            "Error: target chip '{chip}' must be between 1 and {} bytes",
+            tlv::MAX_TARGET_CHIP_LEN
+        );
+        std::process::exit(BAD_TARGET);
+    }
+
+    std::process::exit(pack_bin(file_path, target_chip));
 }
 
 fn unpack_ota(file_path: PathBuf) -> i32 {
@@ -141,7 +158,7 @@ fn unpack_ota(file_path: PathBuf) -> i32 {
 }
 
 // TODO: Optimize memory usage by streaming the file instead of reading it all at once
-fn pack_bin(file_path: PathBuf) -> i32 {
+fn pack_bin(file_path: PathBuf, target_chip: Option<&str>) -> i32 {
     println!("Packing {} as OTA...", file_path.display());
 
     let firmware_size = match file_path.metadata() {
@@ -196,8 +213,20 @@ fn pack_bin(file_path: PathBuf) -> i32 {
     // More than enough for the header
     let mut buf = [0u8; 512];
 
-    let header_len =
-        OtaHeader::new(ota_type, firmware_sha256.as_slice(), firmware_size).serialize(&mut buf);
+    match target_chip {
+        Some(chip) => println!("Target chip: {chip}"),
+        None => println!(
+            "Target chip: not recorded (device cannot screen this image; pass --target to enable it)"
+        ),
+    }
+
+    let header_len = OtaHeader::new(
+        ota_type,
+        firmware_sha256.as_slice(),
+        firmware_size,
+        target_chip,
+    )
+    .serialize(&mut buf);
 
     println!("OTA header length: {} bytes", header_len);
 

--- a/ota/src/handler.rs
+++ b/ota/src/handler.rs
@@ -66,6 +66,7 @@ impl<W: OtaActions> UpdateProcessor<W> {
                 ota_type: None,
                 firmware_blob_size: None,
                 sha256_checksum: None,
+                target_chip: None,
             },
             ota_writer,
             tlv_holder: [0; tlv::MAX_TLV_SIZE as usize],
@@ -186,6 +187,26 @@ impl<W: OtaActions> UpdateProcessor<W> {
                 self.tlv_holder.fill(0);
                 self.current_len = 0;
             }
+            tlv::Tlv::TargetChip { chip } => {
+                if self.header.ota_type.is_none() {
+                    error!("UpdateProcessor: Received Target Chip TLV before OTA Type TLV");
+                    self.state = UpdateProcessorState::Error(OtaError::IllegalOperation);
+                    return Err(OtaError::IllegalOperation);
+                }
+                if chip.as_str() != W::TARGET_CHIP {
+                    error!(
+                        "UpdateProcessor: image is built for {} but this device is {}, refusing it",
+                        chip.as_str(),
+                        W::TARGET_CHIP
+                    );
+                    self.state = UpdateProcessorState::Error(OtaError::TargetMismatch);
+                    return Err(OtaError::TargetMismatch);
+                }
+                debug!("Received Target Chip: {}", chip.as_str());
+                self.header.target_chip = Some(chip);
+                self.tlv_holder.fill(0);
+                self.current_len = 0;
+            }
             tlv::Tlv::FirmwareBlob { size } => {
                 self.handle_firmware_blob(size).await?;
             }
@@ -206,6 +227,16 @@ impl<W: OtaActions> UpdateProcessor<W> {
             self.state = UpdateProcessorState::Error(OtaError::IllegalOperation);
             return Err(OtaError::IllegalOperation);
         }
+
+        if self.header.target_chip.is_none() {
+            warn!(
+                "UpdateProcessor: image declares no target chip, cannot check it is built for {}. \
+                 Re-pack it with `packer --target {}`",
+                W::TARGET_CHIP,
+                W::TARGET_CHIP
+            );
+        }
+
         let max_size = W::get_ota_partition_size()
             .await
             .map_err(|_| OtaError::InternalError)?;
@@ -350,6 +381,7 @@ impl<W: OtaActions> UpdateProcessor<W> {
             ota_type: None,
             firmware_blob_size: None,
             sha256_checksum: None,
+            target_chip: None,
         };
     }
 
@@ -371,4 +403,6 @@ pub(crate) enum OtaError {
     VerificationFailed,
     /// Unknown TLV Type encountered during processing
     UnknownTlvType,
+    /// The image declares a target chip that is not the one running
+    TargetMismatch,
 }

--- a/ota/src/lib.rs
+++ b/ota/src/lib.rs
@@ -66,7 +66,7 @@ mod ota_tlv_tests {
                 ota_type: OTA_TYPE_VALUE_SSH_STAMP,
             },
         ];
-        for variant in variants.iter() {
+        for variant in &variants {
             let mut buffer = [0u8; MAX_TLV_SIZE as usize];
             let used = sshwire::write_ssh(&mut buffer, variant).expect("Failed to create SSH sink");
 
@@ -257,6 +257,103 @@ mod ota_tlv_tests {
         assert_eq!(header.ota_type, Some(OTA_TYPE_VALUE_SSH_STAMP));
         assert_eq!(header.firmware_blob_size, Some(2048));
         assert_eq!(header.sha256_checksum, None);
+    }
+
+    #[test]
+    fn target_chip_round_trip() {
+        let variant = Tlv::TargetChip {
+            chip: TargetChipName::try_from("esp32c6").unwrap(),
+        };
+        let mut buffer = [0u8; MAX_TLV_SIZE as usize];
+        let used = sshwire::write_ssh(&mut buffer, &variant).expect("Failed to encode TLV");
+
+        // type + length + "esp32c6"
+        assert_eq!(used, 1 + 1 + 7);
+        assert_eq!(buffer[0], TARGET_CHIP);
+        assert_eq!(buffer[1], 7);
+
+        let (decoded, _) =
+            sshwire::read_ssh::<Tlv>(&buffer[..used], None).expect("Failed to decode TLV");
+        match decoded {
+            Tlv::TargetChip { chip } => assert_eq!(chip.as_str(), "esp32c6"),
+            other => panic!("Decoded the wrong variant: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn target_chip_is_serialized_right_after_ota_type() {
+        // The whole point of the TLV is early rejection, so it must land in
+        // the first bytes a device sees rather than after the checksum.
+        let mut buffer = [0u8; 512];
+        let used = OtaHeader::new(OTA_TYPE_VALUE_SSH_STAMP, &[7u8; 32], 2048, Some("esp32c6"))
+            .serialize(&mut buffer);
+
+        assert_eq!(buffer[0], OTA_TYPE);
+        assert_eq!(buffer[6], TARGET_CHIP);
+
+        let (header, consumed) =
+            OtaHeader::deserialize(&buffer[..used]).expect("Failed to deserialize header");
+        assert_eq!(consumed, used);
+        assert_eq!(
+            header.target_chip.as_ref().map(heapless::String::as_str),
+            Some("esp32c6")
+        );
+        assert_eq!(header.sha256_checksum, Some([7u8; 32]));
+        assert_eq!(header.firmware_blob_size, Some(2048));
+    }
+
+    #[test]
+    fn header_without_target_chip_stays_readable() {
+        // Images packed before the TLV existed must keep working.
+        let mut buffer = [0u8; 512];
+        let used =
+            OtaHeader::new(OTA_TYPE_VALUE_SSH_STAMP, &[7u8; 32], 2048, None).serialize(&mut buffer);
+
+        let (header, _) =
+            OtaHeader::deserialize(&buffer[..used]).expect("Failed to deserialize header");
+        assert_eq!(header.target_chip, None);
+        assert_eq!(header.firmware_blob_size, Some(2048));
+    }
+
+    #[test]
+    fn target_chip_before_ota_type_is_rejected() {
+        let mut buffer = [0u8; 512];
+        let mut offset = 0;
+
+        let target = Tlv::TargetChip {
+            chip: TargetChipName::try_from("esp32c6").unwrap(),
+        };
+        offset += sshwire::write_ssh(&mut buffer[offset..], &target)
+            .expect("Failed to write Target Chip TLV");
+
+        let ota_type_tlv = Tlv::OtaType {
+            ota_type: OTA_TYPE_VALUE_SSH_STAMP,
+        };
+        offset += sshwire::write_ssh(&mut buffer[offset..], &ota_type_tlv)
+            .expect("Failed to write OTA Type TLV");
+
+        assert!(OtaHeader::deserialize(&buffer[..offset]).is_err());
+    }
+
+    #[test]
+    fn overlong_target_chip_is_rejected() {
+        // Hand-rolled: the encoder cannot produce this, a hostile packer can.
+        let mut buffer = [0u8; 512];
+        buffer[0] = TARGET_CHIP;
+        let too_long = MAX_TARGET_CHIP_LEN + 1;
+        buffer[1] = u8::try_from(too_long).expect("test length fits in a u8");
+        for slot in &mut buffer[2..=(2 + MAX_TARGET_CHIP_LEN)] {
+            *slot = b'x';
+        }
+        let len = 2 + too_long;
+
+        assert!(sshwire::read_ssh::<Tlv>(&buffer[..len], None).is_err());
+    }
+
+    #[test]
+    fn non_utf8_target_chip_is_rejected() {
+        let buffer = [TARGET_CHIP, 2, 0xff, 0xfe];
+        assert!(sshwire::read_ssh::<Tlv>(&buffer, None).is_err());
     }
 
     // TODO: Test more error cases, such as incomplete TLVs

--- a/ota/src/sftpserver.rs
+++ b/ota/src/sftpserver.rs
@@ -165,6 +165,12 @@ impl<W: OtaActions> SftpServer for SftpOtaServer<W> {
                     );
                     StatusCode::SSH_FX_OP_UNSUPPORTED
                 }
+                OtaError::TargetMismatch => {
+                    error!(
+                        "SftpServer Write operation refused: image is for a different chip - {e:?}"
+                    );
+                    StatusCode::SSH_FX_OP_UNSUPPORTED
+                }
                 _ => {
                     error!("SftpServer Write operation failed during OTA processing: {e:?}");
                     StatusCode::SSH_FX_FAILURE

--- a/ota/src/tlv.rs
+++ b/ota/src/tlv.rs
@@ -23,6 +23,18 @@ pub type OtaTlvLen = u8;
 pub const OTA_TYPE_VALUE_SSH_STAMP: u32 = 0x7373_6873; // 'sshs' big endian in ASCII
 
 pub const CHECKSUM_LEN: u32 = 32;
+
+/// Maximum length in bytes of a target chip identifier, e.g. `esp32c6`.
+///
+/// Long enough for every name `esp_hal::chip!()` can produce with room to
+/// spare for non-Espressif ports.
+pub const MAX_TARGET_CHIP_LEN: usize = 16;
+
+/// Chip identifier an OTA image was built for, as written by the packer.
+///
+/// Compared verbatim against the running firmware's
+/// [`OtaActions::TARGET_CHIP`](ssh_stamp_hal::OtaActions::TARGET_CHIP).
+pub type TargetChipName = heapless::String<MAX_TARGET_CHIP_LEN>;
 /// Maximum size for LTV (Length-Type-Value) entries in OTA metadata. Used during the reading of OTA parameters.
 ///
 /// Calculated as: `size_of::<OtaTlvType>() + size_of::<OtaTlvLen>() + u8::MAX = 1 + 1 + 255 = 257`
@@ -64,6 +76,7 @@ where
 pub const OTA_TYPE: OtaTlvType = 0;
 pub const FIRMWARE_BLOB: OtaTlvType = 1;
 pub const SHA256_CHECKSUM: OtaTlvType = 2;
+pub const TARGET_CHIP: OtaTlvType = 3;
 
 /// `OTA_TLV` enum for OTA metadata LTV entries
 /// This TLV does not capture length as it will be captured during parsing
@@ -78,6 +91,15 @@ pub enum Tlv {
     Sha256Checksum {
         checksum: [u8; CHECKSUM_LEN as usize],
     },
+    /// Chip the image was built for, e.g. `esp32c6`.
+    ///
+    /// Optional, for backwards compatibility with images packed before this
+    /// TLV existed. When present it **SHOULD come immediately after
+    /// [`Tlv::OtaType`]**: a device rejects a foreign image the moment it
+    /// parses this record, so putting it first means a mismatched `put`
+    /// fails within the first handful of bytes instead of after a full
+    /// upload.
+    TargetChip { chip: TargetChipName },
     /// Contains the length in bytes of the firmware blob.
     /// The firmware blob follows immediately after this TLV.
     ///
@@ -99,6 +121,18 @@ impl SSHEncode for Tlv {
             Tlv::Sha256Checksum { checksum } => {
                 SHA256_CHECKSUM.enc(s)?;
                 enc_len_val(checksum, s)
+            }
+            Tlv::TargetChip { chip } => {
+                // Not `enc_len_val`: the payload is variable-length, so the
+                // length comes from the string rather than `size_of`.
+                TARGET_CHIP.enc(s)?;
+                OtaTlvLen::try_from(chip.len())
+                    .map_err(|_| WireError::PacketWrong)?
+                    .enc(s)?;
+                for byte in chip.as_bytes() {
+                    byte.enc(s)?;
+                }
+                Ok(())
             }
         }
     }
@@ -130,6 +164,24 @@ impl<'de> SSHDecode<'de> for Tlv {
                 dec_check_val_len::<S, u32>(s)?;
                 let ota_type = u32::dec(s)?;
                 Ok(Tlv::OtaType { ota_type })
+            }
+            TARGET_CHIP => {
+                let len = OtaTlvLen::dec(s)? as usize;
+                if len > MAX_TARGET_CHIP_LEN {
+                    error!("Target chip TLV is {len} bytes, maximum is {MAX_TARGET_CHIP_LEN}");
+                    return Err(WireError::PacketWrong);
+                }
+                let mut name = [0u8; MAX_TARGET_CHIP_LEN];
+                for element in &mut name[..len] {
+                    *element = u8::dec(s)?;
+                }
+                let name = core::str::from_utf8(&name[..len]).map_err(|_| {
+                    error!("Target chip TLV is not valid UTF-8");
+                    WireError::PacketWrong
+                })?;
+                let mut chip = TargetChipName::new();
+                chip.push_str(name).map_err(|_| WireError::PacketWrong)?;
+                Ok(Tlv::TargetChip { chip })
             }
             _ => {
                 error!("Unknown TLV type encountered: {tlv_type}");
@@ -256,14 +308,33 @@ pub struct OtaHeader {
     pub(crate) firmware_blob_size: Option<u32>,
     /// Expected sha256 checksum of the firmware, if provided
     pub sha256_checksum: Option<[u8; tlv::CHECKSUM_LEN as usize]>,
+    /// Chip this image was built for, if the packer recorded one.
+    ///
+    /// `None` for images packed before the [`Tlv::TargetChip`] record
+    /// existed; those cannot be screened and are accepted with a warning.
+    pub target_chip: Option<tlv::TargetChipName>,
 }
 
 impl OtaHeader {
     /// Creates a new OTA header with the provided parameters
     ///
     /// Used during packing of OTA files. Therefore, not needed in the embedded side.
+    ///
+    /// `target_chip` is optional: passing `None` produces an image without a
+    /// [`Tlv::TargetChip`] record, which any device will accept. Passing a
+    /// chip name lets a device reject the image immediately if it does not
+    /// match.
+    ///
+    /// # Panics
+    /// Panics if `target_chip` is longer than [`tlv::MAX_TARGET_CHIP_LEN`].
     #[cfg(not(target_os = "none"))]
-    pub fn new(ota_type: u32, sha256_checksum: &[u8], firmware_blob_size: u32) -> Self {
+    #[must_use]
+    pub fn new(
+        ota_type: u32,
+        sha256_checksum: &[u8],
+        firmware_blob_size: u32,
+        target_chip: Option<&str>,
+    ) -> Self {
         // TODO: Check that the sha256_checksum length is correct: 32 bytes
         let mut checksum_array = [0u8; tlv::CHECKSUM_LEN as usize];
         checksum_array.copy_from_slice(sha256_checksum);
@@ -271,6 +342,14 @@ impl OtaHeader {
             ota_type: Some(ota_type),
             firmware_blob_size: Some(firmware_blob_size),
             sha256_checksum: Some(checksum_array),
+            target_chip: target_chip.map(|chip| {
+                tlv::TargetChipName::try_from(chip).unwrap_or_else(|_| {
+                    panic!(
+                        "target chip {chip:?} exceeds {} bytes",
+                        tlv::MAX_TARGET_CHIP_LEN
+                    )
+                })
+            }),
         }
     }
 
@@ -285,6 +364,14 @@ impl OtaHeader {
             let tlv = tlv::Tlv::OtaType { ota_type };
             let used = sunset::sshwire::write_ssh(&mut buf[offset..], &tlv)
                 .expect("Failed to serialize OTA Type TLV");
+            offset += used;
+        }
+        // Straight after the OTA type, so a mismatched device bails out on
+        // the first write it receives.
+        if let Some(chip) = &self.target_chip {
+            let tlv = tlv::Tlv::TargetChip { chip: chip.clone() };
+            let used = sunset::sshwire::write_ssh(&mut buf[offset..], &tlv)
+                .expect("Failed to serialize Target Chip TLV");
             offset += used;
         }
         if let Some(checksum) = &self.sha256_checksum {
@@ -315,6 +402,7 @@ impl OtaHeader {
         let mut ota_type = None;
         let mut firmware_blob_size = None;
         let mut sha256_checksum = None;
+        let mut target_chip = None;
 
         while source.remaining() > 0 {
             match tlv::Tlv::dec(&mut source) {
@@ -335,6 +423,10 @@ impl OtaHeader {
                             Self::check_ota_is_first_tlv(ota_type)?;
                             sha256_checksum = Some(checksum);
                         }
+                        tlv::Tlv::TargetChip { chip } => {
+                            Self::check_ota_is_first_tlv(ota_type)?;
+                            target_chip = Some(chip);
+                        }
                         tlv::Tlv::FirmwareBlob { size } => {
                             Self::check_ota_is_first_tlv(ota_type)?;
                             firmware_blob_size = Some(size);
@@ -352,6 +444,7 @@ impl OtaHeader {
                 ota_type,
                 firmware_blob_size,
                 sha256_checksum,
+                target_chip,
             },
             source.used(),
         ))
@@ -359,7 +452,7 @@ impl OtaHeader {
 
     fn check_ota_is_first_tlv(ota_type: Option<u32>) -> Result<(), WireError> {
         if ota_type.is_none() {
-            error!("SHA256 Checksum TLV encountered before OTA Type TLV. Ignoring it");
+            error!("TLV encountered before the OTA Type TLV, which must come first");
             Err(sunset::sshwire::WireError::PacketWrong)
         } else {
             Ok(())

--- a/ssh-stamp-esp32/src/flash.rs
+++ b/ssh-stamp-esp32/src/flash.rs
@@ -150,6 +150,10 @@ impl Default for EspOtaWriter {
 }
 
 impl OtaActions for EspOtaWriter {
+    // esp-hal derives this from the chip feature, so it cannot drift out of
+    // sync with what was actually built.
+    const TARGET_CHIP: &'static str = esp_hal::chip!();
+
     async fn try_validating_current_ota_partition() -> Result<(), HalError> {
         let Some(fb) = get_flash_n_buffer() else {
             error!("Flash storage not initialized");

--- a/ssh-stamp-hal/src/traits/flash.rs
+++ b/ssh-stamp-hal/src/traits/flash.rs
@@ -23,6 +23,14 @@ use crate::HalError;
 ///
 /// All methods return `HalError` on failure.
 pub trait OtaActions {
+    /// Identifier of the chip this firmware was built for, e.g. `"esp32c6"`.
+    ///
+    /// An incoming OTA image may carry the chip it was packed for; if the two
+    /// disagree the transfer is refused before any of it reaches flash. Use
+    /// the same spelling as the port's build tooling (`esp_hal::chip!()` on
+    /// Espressif parts) so a `packer --target` invocation is predictable.
+    const TARGET_CHIP: &'static str;
+
     /// Validate the current OTA partition.
     fn try_validating_current_ota_partition() -> impl Future<Output = Result<(), HalError>> + Send;
 


### PR DESCRIPTION
Tries to address points raised in #76.

An image for the wrong chip is not merely useless, it is a brick waiting to happen, and nothing in the format identified what an image was built for. Record it and check it.

- tlv: new TargetChip TLV (type 3) holding the chip name as UTF-8, serialized straight after OtaType so it lands at byte 6. A device that reads a name other than its own aborts the transfer by byte 15 with SSH_FX_OP_UNSUPPORTED, so a mismatched `put` fails immediately instead of after a full upload.
- hal: OtaActions::TARGET_CHIP, implemented on Espressif as esp_hal::chip!() so it cannot drift from what was actually built.
- packer: --target <CHIP>, optional. Images packed without it carry no TargetChip record, cannot be screened, and are accepted with a warning naming the chip that should have been passed. That keeps every image packed to date flashable.

Compatibility runs one way only: an image packed with --target is rejected by firmware predating this record, which treats any unknown TLV as fatal. Hence opt-in rather than unconditional.

Adds docs/OTA.md, which the format previously lacked entirely: packing, uploading, the wire layout, and a per-board support table. Every board listed was built with sftp-ota to fill it; only esp32c6-devkitc is verified on hardware.

Unknown TLVs stay fatal. Skipping them would walk back a Radically Open Security audit finding; the doc sketches the critical/non-critical type split that would be needed to relax it safely.