### PR TITLE
Add rust-doc-generated boards table based on board .toml's

### DIFF
--- a/docs/BUILDING.md
+++ b/docs/BUILDING.md
@@ -78,6 +78,12 @@ cargo xtask ci          # all of the above, for every board and chip
 1. Drop a `boards/<name>.toml` into the relevant BSP crate, with the pin map
    and a `[build]` section naming its chip:
    ```toml
+   [pins]
+   uart_rx = 10
+   uart_tx = 11
+   # can_tx / can_rx and i2c_sda / i2c_scl for the buses the board breaks
+   # out; leave out the ones it does not, they show up as `x` in the catalog
+
    [build]
    chip = "esp32c6"
    # features = ["can"]   # optional: features this board always needs
@@ -85,7 +91,10 @@ cargo xtask ci          # all of the above, for every board and chip
 2. Add the matching `board-<name>` feature in that platform's `Cargo.toml`.
 
 That is it — `cargo xtask list` picks it up by scanning the boards
-directory, so no alias, matrix entry or xtask code has to change.
+directory, so no alias, matrix entry or xtask code has to change. The pin
+catalog on the BSP crate's documentation front page is regenerated from the
+TOML files by `cargo xtask doc`, so the new board appears there too without
+anyone editing a table.
 
 ## Adding a chip or a new vendor
 

--- a/docs/USING.md
+++ b/docs/USING.md
@@ -67,21 +67,26 @@ Notes:
 
 If your SSH client doesn't forward environment variables by default, use the `-o SendEnv=VAR` option as shown above or configure `SendEnv` in your SSH client config.
 
-# UART pins
+# Pin assignments
 
-UART RX/TX pins are defined per-board in `boards/*.toml` files inside the
-`ssh-stamp-esp32-boards` crate. Each board feature (e.g.
-`board-esp32c6-devkitc`) selects a specific PCB and its pin assignments.
-The TOML files are the single source of truth — no other file in the
-repository hard-codes UART pin numbers.
+UART, CAN and I2C pins are defined per-board in `boards/*.toml` files inside
+the board support crate of each platform (`ssh-stamp-esp32-boards` for the
+Espressif one). Each board feature (e.g. `board-esp32c6-devkitc`) selects a
+specific PCB and its pin assignments. The TOML files are the single source of
+truth — no other file in the repository hard-codes pin numbers.
 
-To see the available boards and their pin assignments, run:
+To see which GPIO each bus uses on each board, and which buses a board does
+not support yet, build the documentation:
 
 ```
 cargo xtask doc
 ```
 
-(`cargo xtask list` gives the same board list as a quick terminal summary.)
+Then open the board support crate's front page,
+`target/riscv32imac-unknown-none-elf/doc/ssh_stamp_esp32_boards/index.html`.
+Its catalog table is regenerated from the TOML files on every run.
+(`cargo xtask doc --open` opens a browser on the `ssh-stamp` crate instead;
+the crate list in the sidebar reaches every other crate, this one included.)
 
-Then open `target/riscv32imac-unknown-none-elf/doc/ssh_stamp_esp32_boards/index.html`,
-which contains the auto-generated per-board pin assignment table.
+(`cargo xtask list` gives the board list as a quick terminal summary, without
+the pins.)

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -6,8 +6,8 @@
 //!
 //! Every incoming SSH event is dispatched here by the connection loop in
 //! [`serve`](crate::serve). The main entry point is [`session_env`], which
-//! routes environment variable requests to handlers like [`pubkey_env`] and
-//! [`wifi_ssid_env`].
+//! routes environment variable requests to handlers like [`pubkey_env`],
+//! [`wifi_ap_ssid_env`] and [`wifi_sta_ssid_env`].
 //!
 //! First-boot provisioning also flows through here: when `first_login` is true,
 //! the device accepts any SSH connection (empty password) and allows the

--- a/ssh-stamp-esp32-boards/build.rs
+++ b/ssh-stamp-esp32-boards/build.rs
@@ -13,7 +13,11 @@
 //!   files, which are the single source of truth.
 //! - The `select_board!` macro that expands to the `cfg_if!` + `use` block,
 //!   so the binary has zero per-board lines.
-//! - A rustdoc board-catalog table.
+//!
+//! It also writes `OUT_DIR/board_catalog.md`, the UART/CAN/I2C pin table that
+//! `src/lib.rs` includes into this crate's front page. Every platform's BSP
+//! crate generates its own, so the table always sits with the boards it
+//! describes instead of in a top-level page or a Markdown file under `docs/`.
 //!
 //! Adding a board = add a `boards/{name}.toml` file + a `board-{name}` feature
 //! in `Cargo.toml`. No `.rs` file, no macro editing.
@@ -81,6 +85,7 @@ struct BoardDef {
     url: Option<String>,
     pins: Pins,
     can_mux: Option<CanMux>,
+    build: Option<BuildSection>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -89,6 +94,15 @@ struct Pins {
     uart_tx: u8,
     can_tx: Option<u8>,
     can_rx: Option<u8>,
+    i2c_sda: Option<u8>,
+    i2c_scl: Option<u8>,
+}
+
+/// The `[build]` section belongs to `cargo xtask`; the catalog reads the
+/// chip name out of it so the table can say which MCU each board carries.
+#[derive(Debug, Deserialize)]
+struct BuildSection {
+    chip: Option<String>,
 }
 
 /// Boards that share their CAN pins with other functions behind an
@@ -108,10 +122,13 @@ struct Board {
     struct_name: String,
     feature: String,
     url: Option<String>,
+    chip: Option<String>,
     uart_rx: u8,
     uart_tx: u8,
     can_tx: Option<u8>,
     can_rx: Option<u8>,
+    i2c_sda: Option<u8>,
+    i2c_scl: Option<u8>,
     can_mux: Option<CanMux>,
 }
 
@@ -163,8 +180,8 @@ fn main() -> Result<()> {
     validate_features(&boards)?;
 
     let out_dir = PathBuf::from(std::env::var_os("OUT_DIR").ok_or("OUT_DIR not set by cargo")?);
-    let out_path = out_dir.join("boards_gen.rs");
-    fs::write(&out_path, generate_code(&boards)?)?;
+    fs::write(out_dir.join("boards_gen.rs"), generate_code(&boards)?)?;
+    fs::write(out_dir.join("board_catalog.md"), generate_catalog(&boards)?)?;
 
     Ok(())
 }
@@ -205,10 +222,13 @@ fn load_boards(boards_dir: &Path) -> Result<Vec<Board>> {
             struct_name: to_pascal_case(&stem),
             feature: format!("board-{stem}"),
             url: def.url,
+            chip: def.build.and_then(|b| b.chip),
             uart_rx: def.pins.uart_rx,
             uart_tx: def.pins.uart_tx,
             can_tx: def.pins.can_tx,
             can_rx: def.pins.can_rx,
+            i2c_sda: def.pins.i2c_sda,
+            i2c_scl: def.pins.i2c_scl,
             can_mux: def.can_mux,
         });
     }
@@ -249,7 +269,6 @@ fn generate_code(boards: &[Board]) -> Result<String> {
 
     out.push_str(HEADER);
     gen_structs(&mut out, boards)?;
-    gen_catalog(&mut out, boards)?;
     gen_take_uart_pins(&mut out, boards);
     gen_take_can_pins(&mut out, boards);
     gen_setup_can_transceiver(&mut out, boards);
@@ -277,29 +296,92 @@ fn gen_structs(out: &mut String, boards: &[Board]) -> Result<()> {
     Ok(())
 }
 
-fn gen_catalog(out: &mut String, boards: &[Board]) -> Result<()> {
-    // A rustdoc table summarising all boards — rendered in `cargo doc` output
-    // as the `board_catalog` module page. This is the "one place to look" that
-    // replaces the old hand-maintained README pin table.
-    writeln!(
-        out,
-        "/// # Available boards\n///\n/// | Board feature | UART RX | UART TX | CAN TX | CAN RX | URL |\n/// |---|---|---|---|---|---|"
-    )?;
+/// Prose around the generated pin table. `{table}` receives the rows,
+/// `{mux_note}` a sentence that is only relevant when some board on this
+/// platform muxes its pins.
+const CATALOG_TMPL: &str = r"# Board catalog
+
+Pin allocation for every board of this platform, generated from its
+`boards/*.toml` files on each `cargo doc` (`cargo xtask doc`) run. The TOML
+files are the single source of truth: this table is the only place the
+allocation is written down, and no README, guide or hand-written doc page
+repeats it.
+
+{table}
+Cells are GPIO numbers. `x` marks a bus that is neither supported nor tested
+on that board yet — either the hardware does not break it out, or nothing has
+driven it there so far. Adding the pins to the board's TOML is what fills the
+cell in, here and in the firmware.
+{mux_note}
+Select a board with `cargo xtask build <board>`, or with
+`--features board-<board>` when driving cargo directly.
+";
+
+/// Appended to the catalog when at least one board has a `[can_mux]`.
+const CATALOG_MUX_NOTE: &str = "
+Pins marked `(mux)` are not a bus of their own: the firmware drives them to
+steer an on-board switch or IO expander (the `[can_mux]` section of the
+board's TOML) before it can use the bus they route.
+";
+
+/// The table's fixed part: header row plus alignment row.
+const CATALOG_HEADER: &str = "\
+| Board | Chip | UART RX | UART TX | CAN TX | CAN RX | I2C SDA | I2C SCL |
+|---|---|---|---|---|---|---|---|
+";
+
+/// A GPIO cell: the number, or `x` when the board has no such pin.
+fn pin_cell(pin: Option<u8>) -> String {
+    pin.map_or_else(|| "x".to_string(), |n| n.to_string())
+}
+
+/// An I2C cell. A board can expose I2C pins in `[pins]`, or carry them only
+/// as the control bus of a `[can_mux]`; the two are worth telling apart.
+fn i2c_cell(pin: Option<u8>, mux_pin: Option<u8>) -> String {
+    match (pin, mux_pin) {
+        (Some(n), _) => n.to_string(),
+        (None, Some(n)) => format!("{n} (mux)"),
+        (None, None) => "x".to_string(),
+    }
+}
+
+/// Render the board catalog as a Markdown page.
+///
+/// Included verbatim into the crate documentation by `src/lib.rs`, which puts
+/// the table on this platform's front page rather than in a module of its own
+/// or in a Markdown file under `docs/`.
+fn generate_catalog(boards: &[Board]) -> Result<String> {
+    let mut table = String::from(CATALOG_HEADER);
     for b in boards {
-        let url = match &b.url {
-            Some(u) => format!("<{u}>"),
-            None => "—".to_string(),
+        // The board name doubles as the link to the vendor's board page, so
+        // the table stays narrow enough to read without a URL column.
+        let name = match &b.url {
+            Some(url) => format!("[`{}`]({url})", b.name),
+            None => format!("`{}`", b.name),
         };
-        let can_tx = b.can_tx.map_or("—".to_string(), |v| v.to_string());
-        let can_rx = b.can_rx.map_or("—".to_string(), |v| v.to_string());
+        let mux = b.can_mux.as_ref();
         writeln!(
-            out,
-            "/// | `{}` | {} | {} | {} | {} | {} |",
-            b.feature, b.uart_rx, b.uart_tx, can_tx, can_rx, url,
+            table,
+            "| {name} | {chip} | {} | {} | {} | {} | {} | {} |",
+            b.uart_rx,
+            b.uart_tx,
+            pin_cell(b.can_tx),
+            pin_cell(b.can_rx),
+            i2c_cell(b.i2c_sda, mux.map(|m| m.i2c_sda)),
+            i2c_cell(b.i2c_scl, mux.map(|m| m.i2c_scl)),
+            chip = b.chip.as_deref().unwrap_or("x"),
         )?;
     }
-    writeln!(out, "pub mod board_catalog {{}}\n")?;
-    Ok(())
+
+    let mux_note = if boards.iter().any(|b| b.can_mux.is_some()) {
+        CATALOG_MUX_NOTE
+    } else {
+        ""
+    };
+
+    Ok(CATALOG_TMPL
+        .replace("{table}", &table)
+        .replace("{mux_note}", mux_note))
 }
 
 /// Per-board `#[cfg]` branch inside `take_uart_pins!`.

--- a/ssh-stamp-esp32-boards/src/lib.rs
+++ b/ssh-stamp-esp32-boards/src/lib.rs
@@ -12,20 +12,18 @@
 //!
 //! The TOML files are the single source of truth for pin numbers. No human
 //! writes or edits the generated Rust code.
-//!
+#![doc = include_str!(concat!(env!("OUT_DIR"), "/board_catalog.md"))]
 //! # Adding a board
 //!
-//! 1. Create `boards/{board-name}.toml` with a `[pins]` section (`uart_rx`,
-//!    `uart_tx`) and an optional `url`.
+//! 1. Create `boards/{board-name}.toml` with a `[pins]` section (`uart_rx`
+//!    and `uart_tx`, plus `can_tx`/`can_rx` and `i2c_sda`/`i2c_scl` for the
+//!    buses the board breaks out), a `[build]` section naming its chip, and
+//!    an optional `url`.
 //! 2. Add `board-{name} = []` to `[features]` in `Cargo.toml`.
 //!
 //! No `.rs` file, no macro editing, no binary changes. The `build.rs`
-//! validates that selected features have matching TOML files.
-//!
-//! # Available boards
-//!
-//! See the [`board_catalog`] module for the generated table.
-
+//! validates that selected features have matching TOML files, and the board
+//! shows up in the catalog above on the next `cargo xtask doc`.
 #![no_std]
 
 /// Board identification trait.

--- a/ssh-stamp-esp32/src/bin/ssh-stamp-esp32.rs
+++ b/ssh-stamp-esp32/src/bin/ssh-stamp-esp32.rs
@@ -13,12 +13,13 @@
 //! Brings up ESP-specific peripherals (heap, flash, RNG, UART, radio), then
 //! hands control to the platform-agnostic [`ssh_stamp::app::run_app`].
 //!
-//! # UART Pin Assignments
+//! # Pin assignments
 //!
-//! UART pin numbers are defined per-board in `boards/*.toml` files in the
-//! `ssh-stamp-esp32-boards` crate. Select a board via a `board-<name>` feature
-//! (e.g. `board-esp32c6-devkitc`). See the `ssh-stamp-esp32-boards` crate
-//! documentation for the full list.
+//! UART, CAN and I2C pin numbers are defined per-board in `boards/*.toml`
+//! files in the `ssh-stamp-esp32-boards` crate. Select a board via a
+//! `board-<name>` feature (e.g. `board-esp32c6-devkitc`). That crate's front
+//! page carries the generated catalog: which GPIO each bus uses on each
+//! board, and which buses a board does not support yet.
 
 #![no_std]
 #![no_main]

--- a/ssh-stamp-esp32/src/uart.rs
+++ b/ssh-stamp-esp32/src/uart.rs
@@ -137,8 +137,9 @@ impl BufferedSerial for BufferedUart {
 
 /// UART pins configuration.
 ///
-/// The pin numbers inside are target-specific. See the `ssh-stamp-esp32`
-/// binary's module documentation for the per-target GPIO assignment table.
+/// The pin numbers inside come from the selected board's TOML in the
+/// `ssh-stamp-esp32-boards` crate; its front page carries the generated pin
+/// catalog for every board of this platform.
 pub struct EspUartPins<'a> {
     pub rx: AnyPin<'a>,
     pub tx: AnyPin<'a>,

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -30,7 +30,8 @@ COMMANDS:
     run <target> [opts]     Build, flash and monitor a board
     clippy [<target>]       Lint (defaults to the registry's default board)
     fmt [--check]           Format the workspace
-    doc                     Build the rustdoc for all library crates
+    doc [--open]            Build the rustdoc for all library crates,
+                            including each platform's board pin catalog
     test                    Run the host-side test suites
     ci                      Everything CI checks: every target, lints, format
 
@@ -38,6 +39,7 @@ OPTIONS:
     --features <a,b>        Extra cargo features, comma or space separated
     --profile <name>        Cargo profile override (default: release)
     --check                 For `fmt`: check instead of rewriting
+    --open                  For `doc`: open the docs in a browser afterwards
     -- <args...>            Everything after `--` is passed through to cargo
 
 EXAMPLES:
@@ -45,6 +47,7 @@ EXAMPLES:
     cargo xtask build esp32c3                       # chip only, library build
     cargo xtask run waveshare-esp32-s3-touch-lcd-43 --features can-no-ack
     cargo xtask build esp32c6-devkitc -- --timings
+    cargo xtask doc --open                          # docs, then a browser
 ";
 
 fn main() -> ExitCode {
@@ -77,7 +80,7 @@ fn run() -> Result<(), String> {
         "run" => build(&root, &registry, &args, true),
         "clippy" => clippy(&root, &registry, &args),
         "fmt" => fmt(&root, &registry, &args),
-        "doc" => doc(&root, &registry),
+        "doc" => doc(&root, &registry, &args),
         "test" => test(&root, &registry),
         "ci" => ci(&root, &registry),
         "-h" | "--help" | "help" => {
@@ -104,6 +107,7 @@ struct Args {
     features: Vec<String>,
     profile: Option<String>,
     check: bool,
+    open: bool,
     /// Everything after a literal `--`, forwarded to cargo verbatim.
     passthrough: Vec<String>,
 }
@@ -120,6 +124,7 @@ impl Args {
                     break;
                 }
                 "--check" => args.check = true,
+                "--open" => args.open = true,
                 "--features" => {
                     let value = raw
                         .next()
@@ -324,7 +329,17 @@ fn fmt(root: &Path, registry: &Registry, args: &Args) -> Result<(), String> {
     exec(root, cmd)
 }
 
-fn doc(root: &Path, registry: &Registry) -> Result<(), String> {
+/// Build the rustdoc for the library crates.
+///
+/// Each platform's BSP build script regenerates its board pin catalog from
+/// `boards/*.toml` as part of this, so the table on that crate's front page
+/// is never stale.
+///
+/// With `--open`, the first package in `doc-packages` is opened in a browser
+/// once the build succeeds; rustdoc's sidebar reaches the rest of the
+/// workspace from there. Cargo's own `--open` would land on `ota`, the
+/// alphabetically first of the `-p` flags.
+fn doc(root: &Path, registry: &Registry, args: &Args) -> Result<(), String> {
     let board = registry.defaults.board.clone();
     let unit = resolve(registry, &board)?;
     let platform = registry.platform_of(unit.chip)?;
@@ -348,7 +363,39 @@ fn doc(root: &Path, registry: &Registry) -> Result<(), String> {
     if unit.chip.build_std {
         cmd.arg("-Zbuild-std=core,alloc");
     }
-    exec(root, cmd)
+    exec(root, cmd)?;
+
+    if args.open {
+        let entry = registry
+            .defaults
+            .doc_packages
+            .first()
+            .ok_or("doc-packages is empty, nothing to open")?;
+        let page = root
+            .join("target")
+            .join(&unit.chip.target)
+            .join("doc")
+            .join(entry.replace('-', "_"))
+            .join("index.html");
+        open(&page)?;
+    }
+    Ok(())
+}
+
+/// Hand a generated page to the desktop's browser.
+fn open(page: &Path) -> Result<(), String> {
+    let opener = if cfg!(target_os = "macos") {
+        "open"
+    } else {
+        "xdg-open"
+    };
+    println!("\x1b[1;36m>\x1b[0m {opener} {}", page.display());
+    // The browser outlives us, so spawn instead of waiting for it.
+    Command::new(opener)
+        .arg(page)
+        .spawn()
+        .map(drop)
+        .map_err(|e| format!("`{opener}` failed on {}: {e}", page.display()))
 }
 
 fn test(root: &Path, registry: &Registry) -> Result<(), String> {
@@ -376,7 +423,7 @@ fn ci(root: &Path, registry: &Registry) -> Result<(), String> {
             ..Args::default()
         },
     )?;
-    doc(root, registry)?;
+    doc(root, registry, &Args::default())?;
     test(root, registry)
 }
 


### PR DESCRIPTION
Adds a convenient way to know which boards are supported, per platform:

> Compile a spreadsheet of commercially available "stamp boards" and set a default, unused UART physical pins pair. (...) (see GH issue #23).

This "auto-regenerating spreadsheet" lists the currently supported boards and their corresponding default pins fetched from the SSOT (board .toml files).

Documenting this statically would have been a nightmare :-S