### PR TITLE
Add SSH_STAMP_UART_ variables for parity/stop_bits/etc...

### DIFF
--- a/docs/USING.md
+++ b/docs/USING.md
@@ -59,10 +59,21 @@ ssh -o SendEnv=SSH_STAMP_WIFI_BAND root@192.168.4.1
 ```
 Accepts `2.4g` (default), `5g`, or `auto`. The device resets after applying the change.
 
+- To set the UART bridge line parameters (defaults to 115200 8N1):
+```
+export SSH_STAMP_UART_BAUD="921600"
+export SSH_STAMP_UART_DATA_BITS="8"
+export SSH_STAMP_UART_PARITY="none"
+export SSH_STAMP_UART_STOP_BITS="1"
+ssh -o SendEnv='SSH_STAMP_UART_*' root@192.168.4.1
+```
+Accepted values: baud `300`-`5000000`, data bits `5`-`8`, parity `none`/`even`/`odd`, stop bits `1`/`2`. Each is persisted independently, so only the ones you send change.
+
 Notes:
 - `SSH_STAMP_PUBKEY` is accepted on first-boot to add the initial admin key.
 - `SSH_STAMP_WIFI_AP_SSID` and `SSH_STAMP_WIFI_AP_PSK` may be applied while authenticated via pubkey (or on first-boot). After a successful change the device persists the settings and performs a software reset so the new WiFi settings take effect.
 - `SSH_STAMP_WIFI_BAND` selects the AP radio band. Only the ESP32-C5 supports 5GHz; other chips ignore the setting and stay on 2.4GHz.
+- `SSH_STAMP_UART_*` is supported on every target. The bridge configures its UART once at boot, so the device also resets here: the new line settings are live on the next connection.
 - If you prefer a single-step provisioning, export all three env vars locally and forward them with `SendEnv` in the same SSH invocation.
 
 If your SSH client doesn't forward environment variables by default, use the `-o SendEnv=VAR` option as shown above or configure `SendEnv` in your SSH client config.

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,8 +7,8 @@
 //! Configuration types and serialization.
 //!
 //! [`SSHStampConfig`] holds all persistent device state: host key, public keys,
-//! `WiFi` credentials, MAC address, UART pin assignment, and the first-login
-//! flag. It is serialized to flash via the `sunset` SSH wire format and
+//! `WiFi` credentials, MAC address, UART pins and line parameters, and the
+//! first-login flag. It is serialized to flash via the `sunset` SSH wire format and
 //! deserialized on boot by [`store::load_or_create`](crate::store::load_or_create).
 //!
 //! On first boot, [`SSHStampConfig::new`] generates a random SSID and WPA2
@@ -26,6 +26,7 @@ use embassy_net::{Ipv6Cidr, StaticConfigV6};
 use heapless::String;
 use ssh_key::PublicKey;
 use ssh_key::public::KeyData;
+use ssh_stamp_hal::UartParams;
 
 use sunset::packets::Ed25519PubKey;
 use sunset::{KeyType, Result};
@@ -64,6 +65,9 @@ pub struct SSHStampConfig {
     pub ipv6_static: Option<StaticConfigV6>,
     /// UART
     pub uart_pins: UartPins,
+    /// UART line parameters (baud, data bits, parity, stop bits) for the
+    /// serial bridge. Settable via the `SSH_STAMP_UART_*` env vars.
+    pub uart_params: UartParams,
     /// True until a pubkey is provisioned. Further changes require authentication.
     pub first_login: bool,
 }
@@ -84,7 +88,7 @@ const MAC_RANDOM_SENTINEL: [u8; 6] = [0xFF; 6];
 
 impl SSHStampConfig {
     /// Bump this when the format changes
-    pub const CURRENT_VERSION: u8 = 11;
+    pub const CURRENT_VERSION: u8 = 12;
 
     /// Check if configured for random MAC on each boot
     #[must_use]
@@ -144,6 +148,7 @@ impl SSHStampConfig {
             #[cfg(feature = "ipv6")]
             ipv6_static: None,
             uart_pins,
+            uart_params: UartParams::default(),
             first_login: true,
         })
     }
@@ -350,6 +355,12 @@ impl SSHEncode for SSHStampConfig {
         self.uart_pins.rx.enc(s)?;
         self.uart_pins.tx.enc(s)?;
 
+        // Encode UartParams
+        self.uart_params.baud.enc(s)?;
+        self.uart_params.data_bits.enc(s)?;
+        (self.uart_params.parity as u8).enc(s)?;
+        self.uart_params.stop_bits.enc(s)?;
+
         // Persist first-login marker
         self.first_login.enc(s)?;
 
@@ -394,6 +405,18 @@ impl<'de> SSHDecode<'de> for SSHStampConfig {
         let tx: u8 = SSHDecode::dec(s)?;
         let uart_pins = UartPins { rx, tx };
 
+        // Decode UartParams
+        let baud: u32 = SSHDecode::dec(s)?;
+        let data_bits: u8 = SSHDecode::dec(s)?;
+        let parity: u8 = SSHDecode::dec(s)?;
+        let stop_bits: u8 = SSHDecode::dec(s)?;
+        let uart_params = UartParams {
+            baud,
+            data_bits,
+            parity: parity.into(),
+            stop_bits,
+        };
+
         let first_login = SSHDecode::dec(s)?;
 
         Ok(Self {
@@ -409,6 +432,7 @@ impl<'de> SSHDecode<'de> for SSHStampConfig {
             #[cfg(feature = "ipv6")]
             ipv6_static,
             uart_pins,
+            uart_params,
             first_login,
         })
     }

--- a/src/handle.rs
+++ b/src/handle.rs
@@ -146,6 +146,40 @@ pub mod env_parser {
             .ok()
             .map(|band| band as u8)
     }
+
+    // Slowest and fastest baud rates accepted for the bridge. The ceiling is
+    // what the UART peripherals themselves top out at.
+    const UART_BAUD_MIN: u32 = 300;
+    const UART_BAUD_MAX: u32 = 5_000_000;
+
+    /// Parses a UART baud rate, accepting 300 to 5000000 baud.
+    #[must_use]
+    pub fn parse_uart_baud(value: &str) -> Option<u32> {
+        let baud: u32 = value.trim().parse().ok()?;
+        (UART_BAUD_MIN..=UART_BAUD_MAX)
+            .contains(&baud)
+            .then_some(baud)
+    }
+
+    /// Parses the UART data bits per frame, accepting 5 to 8.
+    #[must_use]
+    pub fn parse_uart_data_bits(value: &str) -> Option<u8> {
+        let bits: u8 = value.trim().parse().ok()?;
+        (5..=8).contains(&bits).then_some(bits)
+    }
+
+    /// Parses the UART parity setting, accepting `none`, `even` or `odd`.
+    #[must_use]
+    pub fn parse_uart_parity(value: &str) -> Option<ssh_stamp_hal::Parity> {
+        ssh_stamp_hal::Parity::from_str(value.trim()).ok()
+    }
+
+    /// Parses the UART stop bits per frame, accepting 1 or 2.
+    #[must_use]
+    pub fn parse_uart_stop_bits(value: &str) -> Option<u8> {
+        let bits: u8 = value.trim().parse().ok()?;
+        matches!(bits, 1 | 2).then_some(bits)
+    }
 }
 
 #[derive(Debug)]
@@ -274,7 +308,7 @@ pub async fn session_shell<P: PlatformServices>(
                     .map_err(|_| sunset::error::BadUsage.build())?;
                 drop(config_guard);
                 if *ctx.needs_reset {
-                    info!("Configuration saved. Rebooting to apply WiFi changes...");
+                    info!("Configuration saved. Rebooting to apply the changes...");
                     platform.reset();
                 }
             }
@@ -454,6 +488,18 @@ pub async fn session_env(
             }
             "SSH_STAMP_WIFI_MAC_RANDOM" => {
                 wifi_mac_random_env(a, config, ctx).await?;
+            }
+            "SSH_STAMP_UART_BAUD" => {
+                uart_env(UartParam::Baud, a, config, ctx).await?;
+            }
+            "SSH_STAMP_UART_DATA_BITS" => {
+                uart_env(UartParam::DataBits, a, config, ctx).await?;
+            }
+            "SSH_STAMP_UART_PARITY" => {
+                uart_env(UartParam::Parity, a, config, ctx).await?;
+            }
+            "SSH_STAMP_UART_STOP_BITS" => {
+                uart_env(UartParam::StopBits, a, config, ctx).await?;
             }
             _ => {
                 debug!("Ignoring unknown environment variable: {}", a.name()?);
@@ -695,6 +741,81 @@ pub async fn wifi_mac_random_env(
         *ctx.needs_reset = true;
     } else {
         warn!("SSH_STAMP_WIFI_MAC_RANDOM env received but not authenticated; rejecting");
+        a.fail()?;
+    }
+    Ok(())
+}
+
+/// A UART line parameter, one per `SSH_STAMP_UART_*` environment variable.
+#[derive(Clone, Copy, Debug)]
+pub enum UartParam {
+    Baud,
+    DataBits,
+    Parity,
+    StopBits,
+}
+
+impl UartParam {
+    /// The environment variable this parameter is set from.
+    const fn env_name(self) -> &'static str {
+        match self {
+            Self::Baud => "SSH_STAMP_UART_BAUD",
+            Self::DataBits => "SSH_STAMP_UART_DATA_BITS",
+            Self::Parity => "SSH_STAMP_UART_PARITY",
+            Self::StopBits => "SSH_STAMP_UART_STOP_BITS",
+        }
+    }
+
+    /// The values this parameter accepts, for the rejection log line.
+    const fn accepted(self) -> &'static str {
+        match self {
+            Self::Baud => "300-5000000",
+            Self::DataBits => "5-8",
+            Self::Parity => "none, even or odd",
+            Self::StopBits => "1 or 2",
+        }
+    }
+}
+
+/// Handles the `SSH_STAMP_UART_*` environment variable requests.
+///
+/// The bridge configures its UART once at boot, so a change is persisted and
+/// applied after the reset triggered on the next shell request, like the
+/// `WiFi` settings.
+///
+/// # Errors
+/// Returns an error if SSH protocol operations fail.
+pub async fn uart_env(
+    param: UartParam,
+    a: sunset::event::ServEnvironmentRequest<'_, '_>,
+    config: &SunsetMutex<SSHStampConfig>,
+    ctx: &mut EventContext<'_>,
+) -> Result<(), sunset::Error> {
+    let mut config_guard = config.lock().await;
+    if !(*ctx.auth_checked || config_guard.first_login) {
+        warn!(
+            "{} env received but not authenticated; rejecting",
+            param.env_name()
+        );
+        return a.fail();
+    }
+
+    let value = a.value()?;
+    let uart = &mut config_guard.uart_params;
+    let applied = match param {
+        UartParam::Baud => env_parser::parse_uart_baud(value).map(|v| uart.baud = v),
+        UartParam::DataBits => env_parser::parse_uart_data_bits(value).map(|v| uart.data_bits = v),
+        UartParam::Parity => env_parser::parse_uart_parity(value).map(|v| uart.parity = v),
+        UartParam::StopBits => env_parser::parse_uart_stop_bits(value).map(|v| uart.stop_bits = v),
+    };
+
+    if applied.is_some() {
+        debug!("Set UART {param:?} from ENV: {uart:?}");
+        a.succeed()?;
+        *ctx.config_changed = true;
+        *ctx.needs_reset = true;
+    } else {
+        warn!("{} must be {}", param.env_name(), param.accepted());
         a.fail()?;
     }
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,10 @@
 //! and `SSH_STAMP_WIFI_PSK` env vars. Changes are persisted to flash and the
 //! device performs a software reset.
 //!
+//! The serial bridge line settings follow the same route through the
+//! `SSH_STAMP_UART_BAUD`, `SSH_STAMP_UART_DATA_BITS`, `SSH_STAMP_UART_PARITY`
+//! and `SSH_STAMP_UART_STOP_BITS` env vars, defaulting to 115200 8N1.
+//!
 //! ## Testing
 //!
 //! Host-side OTA TLV tests:

--- a/ssh-stamp-esp32/src/bin/ssh-stamp-esp32.rs
+++ b/ssh-stamp-esp32/src/bin/ssh-stamp-esp32.rs
@@ -169,6 +169,10 @@ async fn main(spawner: Spawner) -> ! {
     }
     .expect("Could not load or create SSHStampConfig");
 
+    // Line settings for the bridge; the UART task is configured with them
+    // below, so `SSH_STAMP_UART_*` changes take effect on the next boot.
+    let uart_params = flash_config.uart_params;
+
     static CONFIG: StaticCell<SunsetMutex<SSHStampConfig>> = StaticCell::new();
     let config: &'static SunsetMutex<SSHStampConfig> = CONFIG.init(SunsetMutex::new(flash_config));
 
@@ -203,8 +207,9 @@ async fn main(spawner: Spawner) -> ! {
             let interrupt_spawner = interrupt_executor.start(Priority::Priority1);
         }
     }
-    interrupt_spawner
-        .spawn(uart_task(uart_buf, peripherals.UART1, pins).expect("uart_task spawn failed"));
+    interrupt_spawner.spawn(
+        uart_task(uart_buf, peripherals.UART1, pins, uart_params).expect("uart_task spawn failed"),
+    );
 
     #[cfg(feature = "can")]
     let can_buf: &'static BufferedCan = {

--- a/ssh-stamp-esp32/src/uart.rs
+++ b/ssh-stamp-esp32/src/uart.rs
@@ -23,14 +23,18 @@ use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, pipe::Pipe};
 use esp_hal::Async;
 use esp_hal::gpio::AnyPin;
 use esp_hal::peripherals::UART1;
-use esp_hal::uart::{Config, RxConfig, Uart};
+use esp_hal::uart::{Config, DataBits, Parity, RxConfig, StopBits, Uart};
 use portable_atomic::{AtomicUsize, Ordering};
 use ssh_stamp::serial::BufferedSerial;
+use ssh_stamp_hal::{Parity as LineParity, UartParams};
 use static_cell::StaticCell;
 
 const INWARD_BUF_SZ: usize = 512;
 const OUTWARD_BUF_SZ: usize = 256;
 const UART_BUF_SZ: usize = 64;
+
+/// The ESP32 UART peripherals reject anything above 5 Mbaud.
+const MAX_BAUD: u32 = 5_000_000;
 
 /// Bidirectional pipe buffer for UART communications.
 pub struct BufferedUart {
@@ -151,18 +155,53 @@ pub static UART_BUF: StaticCell<BufferedUart> = StaticCell::new();
 /// to release [`uart_task`] from its initial wait.
 pub static UART_SIGNAL: Signal<CriticalSectionRawMutex, u8> = Signal::new();
 
+/// Translates the persisted, target-agnostic [`UartParams`] into an esp-hal
+/// [`Config`].
+///
+/// Values the peripheral cannot honour fall back to the 8N1 default instead of
+/// refusing to bring the bridge up, so a stale or corrupt stored config still
+/// leaves a usable serial console.
+fn esp_uart_config(params: UartParams) -> Config {
+    let data_bits = match params.data_bits {
+        5 => DataBits::_5,
+        6 => DataBits::_6,
+        7 => DataBits::_7,
+        _ => DataBits::_8,
+    };
+    let parity = match params.parity {
+        LineParity::Even => Parity::Even,
+        LineParity::Odd => Parity::Odd,
+        LineParity::None => Parity::None,
+    };
+    let stop_bits = if params.stop_bits == 2 {
+        StopBits::_2
+    } else {
+        StopBits::_1
+    };
+
+    Config::default()
+        .with_baudrate(params.baud.clamp(1, MAX_BAUD))
+        .with_data_bits(data_bits)
+        .with_parity(parity)
+        .with_stop_bits(stop_bits)
+}
+
 /// Embassy task that owns the hardware UART and pumps it through
 /// [`BufferedUart::run`]. Spawn from a higher-priority `InterruptExecutor`
 /// for lower latency.
+///
+/// `params` are the line settings from the device config, applied here since
+/// the UART is configured once for the lifetime of the boot.
 #[embassy_executor::task]
 pub async fn uart_task(
     uart_buf: &'static BufferedUart,
     uart1: UART1<'static>,
     pins: EspUartPins<'static>,
+    params: UartParams,
 ) {
     UART_SIGNAL.wait().await;
 
-    let uart_config = Config::default().with_rx(
+    let uart_config = esp_uart_config(params).with_rx(
         RxConfig::default()
             .with_fifo_full_threshold(16)
             .with_timeout(1),

--- a/ssh-stamp-hal/src/config.rs
+++ b/ssh-stamp-hal/src/config.rs
@@ -9,31 +9,92 @@
 use core::str::FromStr;
 use heapless::String;
 
+/// UART parity bit setting.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum Parity {
+    /// No parity bit (default).
+    #[default]
+    None,
+    /// Even parity.
+    Even,
+    /// Odd parity.
+    Odd,
+}
+
+impl FromStr for Parity {
+    type Err = ();
+
+    /// Parses a parity setting from a string value.
+    ///
+    /// Accepts `"none"`/`"n"`, `"even"`/`"e"` or `"odd"`/`"o"` (case-insensitive).
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        if value.eq_ignore_ascii_case("none") || value.eq_ignore_ascii_case("n") {
+            Ok(Self::None)
+        } else if value.eq_ignore_ascii_case("even") || value.eq_ignore_ascii_case("e") {
+            Ok(Self::Even)
+        } else if value.eq_ignore_ascii_case("odd") || value.eq_ignore_ascii_case("o") {
+            Ok(Self::Odd)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl From<u8> for Parity {
+    /// Resolves a `Parity` from its on-wire `u8` representation.
+    ///
+    /// Unknown values fall back to `None` (the default).
+    fn from(value: u8) -> Self {
+        match value {
+            1 => Self::Even,
+            2 => Self::Odd,
+            _ => Self::None,
+        }
+    }
+}
+
+/// UART line parameters for the SSH-to-serial bridge.
+///
+/// Persisted in the device config and applied when the bridge's UART is
+/// brought up, so changes take effect on the next boot. Values are kept
+/// target-agnostic; each port maps them onto its own UART driver types.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct UartParams {
+    /// Baud rate in bits per second.
+    pub baud: u32,
+    /// Data bits per frame (5-8).
+    pub data_bits: u8,
+    /// Parity bit setting.
+    pub parity: Parity,
+    /// Stop bits per frame (1 or 2).
+    pub stop_bits: u8,
+}
+
+impl Default for UartParams {
+    /// The classic 115200 8N1.
+    fn default() -> Self {
+        Self {
+            baud: 115_200,
+            data_bits: 8,
+            parity: Parity::None,
+            stop_bits: 1,
+        }
+    }
+}
+
 /// UART peripheral configuration.
 ///
 /// Pin numbers (`tx_pin`, `rx_pin`) are target-specific and must be set by
 /// the port binary before use. There are no cross-platform default values;
 /// each port crate defines pin assignments in its `src/bin/` entry point.
 /// See the `ssh-stamp-esp32` binary's module documentation for ESP32 defaults.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub struct UartConfig {
     pub tx_pin: u8,
     pub rx_pin: u8,
     pub cts_pin: Option<u8>,
     pub rts_pin: Option<u8>,
-    pub baud_rate: u32,
-}
-
-impl Default for UartConfig {
-    fn default() -> Self {
-        Self {
-            tx_pin: 0,
-            rx_pin: 0,
-            cts_pin: None,
-            rts_pin: None,
-            baud_rate: 115_200,
-        }
-    }
+    pub params: UartParams,
 }
 
 /// `WiFi` band mode for the access point.

--- a/ssh-stamp-hal/src/lib.rs
+++ b/ssh-stamp-hal/src/lib.rs
@@ -66,6 +66,6 @@ pub mod config;
 pub mod error;
 pub mod traits;
 
-pub use config::{BandMode, UartConfig, WifiApConfigStatic};
+pub use config::{BandMode, Parity, UartConfig, UartParams, WifiApConfigStatic};
 pub use error::{FlashError, HalError, HashError, UartError, WifiError};
 pub use traits::*;


### PR DESCRIPTION
Adds serial (UART) parameters control via environment variables. Handy for all types of DUTs that don't go along with the standard 115200 8N1 settings.