### PR TITLE
Switch from sbom-cve-check to cargo audit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,19 @@
 #
 # SBOM tooling: anchore/sbom-action runs Syft on the source tree (Cargo.lock
 # + Cargo.toml) to produce an SPDX JSON SBOM covering all Rust dependencies.
-# The resulting sbom.spdx.json can be fed into bootlin/sbom-cve-check for
-# downstream CVE analysis, which this workflow runs automatically on every
-# release.
+# The resulting sbom.spdx.json is attached to the release for supply-chain
+# transparency.
+#
+# CVE tooling: cargo-audit checks Cargo.lock against the RustSec advisory
+# database. It is used in preference to SBOM-consuming scanners because those
+# match Rust crates poorly -- Grype, fed this exact SBOM, missed both
+# high-severity quick-xml advisories that cargo-audit catches. Note that
+# bootlin/sbom-cve-check cannot consume this SBOM at all: its spdx2 backend
+# only accepts Yocto-style SPDX2 trees, and its spdx3 backend needs true
+# SPDX 3.0, which Syft does not emit.
+#
+# `unmaintained` advisories are reported as warnings and do not fail the
+# release; only actual vulnerabilities do.
 
 name: Release
 
@@ -122,27 +132,35 @@ jobs:
 
   cve-check:
     name: CVE check
-    needs: [generate-sbom]
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Download SBOM artifact
-        uses: actions/download-artifact@v4
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
         with:
-          name: sbom.spdx.json
+          tool: cargo-audit
 
-      - name: Install sbom-cve-check
-        run: pip install "sbom-cve-check[extra]"
-
-      - name: Run CVE analysis
-        run: sbom-cve-check --sbom-path sbom.spdx.json --export-type spdx3 --export-path cve-report.spdx.json
+      # Report first, gate last: cargo-audit writes a valid JSON report even
+      # when it finds advisories, so `|| true` lets the upload below run either
+      # way. Anything that breaks the scan itself still fails the gate step.
+      - name: Generate CVE report
+        run: cargo audit --json > cve-report.json || true
 
       - name: Upload CVE report
         uses: actions/upload-artifact@v4
         with:
           name: cve-report
-          path: cve-report.spdx.json
+          path: cve-report.json
+
+      # The gate. Also the only human-readable output: with --json above,
+      # cargo-audit writes nothing to stderr, so this is what shows which
+      # advisory failed the release.
+      - name: Check for advisories
+        run: cargo audit
 
   publish-release:
     name: Publish GitHub Release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2914,9 +2914,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -19,7 +19,7 @@ workspace = true
 anyhow = "1"
 clap = { version = "4", features = ["derive", "env"] }
 espflash = { version = "4", default-features = false }
-quick-xml = { version = "0.38", default-features = false }
+quick-xml = { version = "0.41", default-features = false }
 tempfile = "3"
 humansize = "2"
 statrs = { version = "0.19", default-features = false }


### PR DESCRIPTION
A couple of failed releases due to CVE SBOM python failing made me reconsider the tooling choices.