### PR TITLE
Provision Wi-Fi SSID and PSK on to the board directly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2343,6 +2343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "macaddr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baee0bbc17ce759db233beb01648088061bf678383130602a298e6998eedb2d8"
+
+[[package]]
 name = "mach2"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4395,9 +4401,12 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
+ "embedded-storage-inmemory",
  "esp-idf-part",
  "espflash",
+ "getrandom",
  "humansize",
+ "macaddr",
  "object 0.37.3",
  "probe-rs",
  "probe-rs-espressif",
@@ -4405,9 +4414,13 @@ dependencies = [
  "serde",
  "serde_json",
  "serial2",
+ "ssh-key",
+ "ssh-stamp",
  "statrs",
  "strip-ansi-escapes",
+ "sunset",
  "tempfile",
+ "toml",
  "xshell",
 ]
 

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -36,3 +36,17 @@ strip-ansi-escapes = "0.2"
 xshell = "0.2"
 probe-rs = "0.32"
 probe-rs-espressif = "0.32"
+
+# We need to depend on the main crate as a library for Wi-Fi provisioning.
+ssh-stamp = { path = ".." }
+sunset = { workspace = true }
+
+# Sunset forces this version of ssh-key.
+ssh-key = { version = "0.7.0-rc.11", default-features = false, features = [
+    "ed25519",
+    "std",
+] }
+embedded-storage-inmemory = "0.1"
+getrandom = "0.4"
+toml = "0.8"
+macaddr = "1"

--- a/xtask/src/board.rs
+++ b/xtask/src/board.rs
@@ -6,8 +6,11 @@
 //! The build level information on boards for ssh-stamp.
 
 use crate::results::CrateSize;
+use crate::util::workspace_root;
 use anyhow::{Context, Result};
 use clap::builder::{PossibleValuesParser, TypedValueParser};
+use ssh_stamp::config::UartPins;
+use std::fs;
 use std::path::PathBuf;
 use xshell::{Shell, cmd};
 
@@ -480,6 +483,51 @@ impl Board {
             }
         }
     }
+
+    /// The UART pins from the board's TOML definition.
+    pub fn uart_pins(&self) -> Result<UartPins> {
+        Ok(BoardToml::from_workspace(self.name)?.uarts_pins())
+    }
+}
+
+/// The parts of a board definition TOML.
+#[derive(serde::Deserialize)]
+pub struct BoardToml {
+    pins: BoardPins,
+}
+
+impl BoardToml {
+    /// Parse the board toml from a string.
+    pub fn parse_from_str(toml: &str) -> Result<BoardToml> {
+        toml::from_str(toml).with_context(|| "could not parse".to_string())
+    }
+
+    /// Create the board configuration from the workspace definition.
+    pub fn from_workspace(name: &str) -> Result<BoardToml> {
+        let path = workspace_root()
+            .join("ssh-stamp-esp32-boards")
+            .join("boards")
+            .join(format!("{name}.toml"));
+        let definition = fs::read_to_string(&path)
+            .with_context(|| format!("could not read {}", path.display()))?;
+
+        Self::parse_from_str(&definition)
+    }
+
+    /// Get the UART pins for this board toml.
+    pub fn uarts_pins(&self) -> UartPins {
+        UartPins {
+            rx: self.pins.uart_rx,
+            tx: self.pins.uart_tx,
+        }
+    }
+}
+
+/// The pin section of a board definition TOML.
+#[derive(serde::Deserialize)]
+pub struct BoardPins {
+    uart_rx: u8,
+    uart_tx: u8,
 }
 
 #[cfg(test)]
@@ -539,6 +587,12 @@ mod tests {
             board.features(&["board-esp32c6-devkitc"]),
             "board-esp32c6-devkitc"
         );
+    }
+
+    #[test]
+    fn uart_pins_from_the_board_toml() {
+        let board = find("esp32c6-devkitc").unwrap();
+        assert_eq!(board.uart_pins().unwrap(), UartPins { rx: 10, tx: 11 });
     }
 
     #[test]

--- a/xtask/src/cmd/bench.rs
+++ b/xtask/src/cmd/bench.rs
@@ -9,26 +9,21 @@
 
 use crate::board::{self, Board};
 use crate::cmd::{self, BENCH_FEATURES};
-use crate::device::{self, Serial};
+use crate::device::{self, Mac, Serial, SshAuth};
 use crate::elf::StackRegion;
-use crate::host::AccessPoint;
+use crate::provision::Provision;
 use crate::record::{self, Record};
 use crate::results::{BenchResults, BenchRun, BootCheckpoint, HeapSnapshot, Results, RunOutcome};
 use crate::stack_probe::StackProbe;
 use crate::stats::{Stats, fmt_bytes, fmt_us, to_f64};
-use anyhow::{Context, Result, bail};
+use anyhow::{Result, bail};
 use clap::Args as ClapArgs;
-use std::env::home_dir;
-use std::fs;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::thread::sleep;
 use std::time::Duration;
 
 /// The variable that overrides the heap size when flashing the firmware.
 const HEAP_ENV_VAR: &str = "SSH_STAMP_CONFIG_HEAP_SIZE";
-
-/// The variable for the public key.
-const PUBKEY_ENV_VAR: &str = "SSH_STAMP_PUBKEY";
 
 #[derive(ClapArgs)]
 pub struct Args {
@@ -41,10 +36,6 @@ pub struct Args {
     /// SSH username.
     #[arg(long, default_value = "root")]
     user: String,
-    /// The public key used for enrolment on the first boot. Defaults to
-    /// `~/.ssh/id_ed25519.pub`.
-    #[arg(long)]
-    pubkey: Option<PathBuf>,
     /// Number of SSH sessions to execute, this controls how many samples are collected
     /// from an SSH session.
     #[arg(long, default_value_t = 10, value_parser = clap::value_parser!(u32).range(1..))]
@@ -166,7 +157,13 @@ fn measure(args: &Args, features: &str, port: &str, heap: Option<u64>) -> Result
         .collect();
 
     board.build(&xshell::Shell::new()?, profile, features, &env)?;
-    device::flash(board, profile, port)?;
+
+    // The device's own MAC should be used so that it's stable across the whole run.
+    let mac = Mac::read(board, port)?;
+
+    eprintln!("=== provisioning a config with new credentials ===");
+    let provision = Provision::generate(&args.host, mac.into_inner(), board.uart_pins()?)?;
+    device::flash(board, profile, port, provision.image())?;
 
     // The flash ends has a reset, and the open must retry.
     let serial = Serial::open(port, args.verbose)?;
@@ -197,7 +194,7 @@ fn measure(args: &Args, features: &str, port: &str, heap: Option<u64>) -> Result
         }
     };
 
-    let access_point = AccessPoint::parse(&serial.current_capture())?;
+    let access_point = provision.access_point();
     if !access_point.wait_for_reachable(&args.host, args.interface.as_deref()) {
         eprintln!("=== the device reports itself ready but is unreachable ===");
         return Ok(RunOutcome::Failed {
@@ -207,13 +204,7 @@ fn measure(args: &Args, features: &str, port: &str, heap: Option<u64>) -> Result
     }
     sleep(Duration::from_secs(1));
 
-    if !enrol(args)? {
-        return Ok(RunOutcome::Failed {
-            heap_size: heap,
-            ready: true,
-        });
-    }
-    let (established, rtt_us) = run_sessions(args)?;
+    let (established, rtt_us) = run_sessions(args, &provision.ssh_auth())?;
 
     sleep(Duration::from_secs(2));
     serial.report_health();
@@ -239,7 +230,7 @@ fn measure(args: &Args, features: &str, port: &str, heap: Option<u64>) -> Result
 }
 
 /// Runs the SSH sessions and collects the round-trip samples.
-fn run_sessions(args: &Args) -> Result<(u32, Vec<u64>)> {
+fn run_sessions(args: &Args, auth: &SshAuth) -> Result<(u32, Vec<u64>)> {
     let opts = args.ssh_opts();
     let mut established = 0;
     let mut failures = 0;
@@ -250,8 +241,14 @@ fn run_sessions(args: &Args) -> Result<(u32, Vec<u64>)> {
         args.sessions, args.user, args.host, args.rtt_iters
     );
     for i in 1..=args.sessions {
-        let session =
-            device::SessionReport::ssh_session(&args.host, &args.user, &opts, &[], args.rtt_iters)?;
+        let session = device::SessionReport::ssh_session(
+            &args.host,
+            &args.user,
+            auth,
+            &opts,
+            &[],
+            args.rtt_iters,
+        )?;
         eprintln!(
             "  session {i:2}: {}, {} of {} markers returned",
             if session.established { "OK" } else { "FAILED" },
@@ -284,59 +281,6 @@ fn run_sessions(args: &Args) -> Result<(u32, Vec<u64>)> {
     eprintln!("=== sessions done, {failures} failures, {timeouts} timeouts ===");
 
     Ok((established, rtt_us))
-}
-
-/// Enrols the public key into the device on first boot. Returns false if the
-/// enrolment session could not be established.
-fn enrol(args: &Args) -> Result<bool> {
-    let Some((path, pubkey)) = read_pubkey(args.pubkey.as_deref())? else {
-        return Ok(true);
-    };
-
-    eprintln!("=== adding {} for public key enrolment ===", path.display());
-    let mut opts = args.ssh_opts();
-    opts.push(format!("SendEnv={PUBKEY_ENV_VAR}"));
-    let envs = [(PUBKEY_ENV_VAR.to_string(), pubkey)];
-
-    let session = device::SessionReport::ssh_session(&args.host, &args.user, &opts, &envs, 0)?;
-    if !session.established {
-        eprintln!("=== the public key failed to enrol ===");
-        return Ok(false);
-    }
-
-    Ok(true)
-}
-
-/// Reads the key to enrol.
-fn read_pubkey(path: Option<&Path>) -> Result<Option<(PathBuf, String)>> {
-    let path = if let Some(path) = path {
-        path.to_path_buf()
-    } else {
-        let Some(home) = home_dir() else {
-            eprintln!("=== no home directory, skipping enrolment ===");
-            return Ok(None);
-        };
-        let default = home.join(".ssh").join("id_ed25519.pub");
-        if !default.exists() {
-            eprintln!(
-                "=== {} not found, skipping enrolment ===",
-                default.display()
-            );
-            return Ok(None);
-        }
-        default
-    };
-
-    let key = fs::read_to_string(&path)
-        .with_context(|| format!("could not read {}", path.display()))?
-        .trim()
-        .to_string();
-
-    if !key.starts_with("ssh-ed25519") {
-        bail!("{} is not an Ed25519 key", path.display());
-    }
-
-    Ok(Some((path, key)))
 }
 
 /// Get the records from captured serial lines and reconstruct them.
@@ -438,7 +382,6 @@ mod tests {
             board: board::find("esp32c6-devkitc").unwrap(),
             host: String::new(),
             user: String::new(),
-            pubkey: None,
             sessions: 1,
             heap,
             port: None,

--- a/xtask/src/device.rs
+++ b/xtask/src/device.rs
@@ -8,9 +8,10 @@ use crate::board::Board;
 use crate::cmd;
 use crate::util::{retry, retry_until};
 use anyhow::{Context, Result, bail};
+use macaddr::MacAddr6;
 use serial2::SerialPort;
 use std::io::{self, BufRead, BufReader, Read, Write};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::{ChildStdin, Command, Stdio};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex, MutexGuard, mpsc};
@@ -28,7 +29,7 @@ pub const BOOT_TIMEOUT: Duration = Duration::from_mins(2);
 pub const SETUP_TIMEOUT: Duration = Duration::from_secs(2);
 
 /// This will flash the firmware onto the board via espflash.
-pub fn flash(board: &Board, profile: &str, port: &str) -> Result<()> {
+pub fn flash(board: &Board, profile: &str, port: &str, config_image: &Path) -> Result<()> {
     let shell = Shell::new()?;
     let soc = board.soc;
     let elf = board.elf_path(profile).display().to_string();
@@ -40,14 +41,75 @@ pub fn flash(board: &Board, profile: &str, port: &str) -> Result<()> {
 
     eprintln!("=== flashing {elf} to {port} for {soc} ===");
 
+    // Hold the reset while the config still has to be written.
     cmd!(
         shell,
-        "espflash flash --port {port} {partitions...} --chip {soc} {elf}"
+        "espflash flash --port {port} {partitions...} --chip {soc} --after no-reset {elf}"
     )
     .run()
     .context("espflash flash failed")?;
 
+    let address = format!("{:#x}", ssh_stamp::store::CONFIG_OFFSET);
+    let image = config_image.display().to_string();
+
+    eprintln!("=== provisioning the config at {address} ===");
+
+    // The default reset after the write boots the provisioned device.
+    cmd!(
+        shell,
+        "espflash write-bin --port {port} --chip {soc} {address} {image}"
+    )
+    .run()
+    .context("espflash write-bin failed")?;
+
     Ok(())
+}
+
+/// The MAC address of the device.
+pub struct Mac([u8; 6]);
+
+impl Mac {
+    /// Reads the device's MAC address.
+    pub fn read(board: &Board, port: &str) -> Result<Self> {
+        let shell = Shell::new()?;
+        let soc = board.soc;
+
+        eprintln!("=== reading the MAC address on {port} ===");
+
+        let output = cmd!(shell, "espflash board-info --port {port} --chip {soc}")
+            .read()
+            .context("espflash board-info failed")?;
+
+        Self::parse(&output)
+    }
+
+    /// Parses the mac address from the espflash output.
+    fn parse(output: &str) -> Result<Self> {
+        let line = output
+            .lines()
+            .find_map(|line| line.strip_prefix("MAC address:"))
+            .context("espflash contains no MAC address")?;
+
+        let mac: MacAddr6 = line
+            .trim()
+            .parse()
+            .context("could not parse the MAC address")?;
+
+        Ok(Self(mac.into_array()))
+    }
+
+    /// The MAC address as bytes.
+    pub fn into_inner(self) -> [u8; 6] {
+        self.0
+    }
+}
+
+/// The settings for the SSH sessions.
+pub struct SshAuth {
+    /// The `known_hosts` file.
+    pub known_hosts: PathBuf,
+    /// The private key that the config has.
+    pub identity: PathBuf,
 }
 
 /// The SSH session report.
@@ -67,12 +129,13 @@ impl SessionReport {
     pub fn ssh_session(
         host: &str,
         user: &str,
+        auth: &SshAuth,
         extra_opts: &[String],
         envs: &[(String, String)],
         markers: u32,
     ) -> Result<Self> {
         let shell = Shell::new()?;
-        let mut child = Self::ssh_session_cmd(&shell, host, user, extra_opts, envs, true)
+        let mut child = Self::ssh_session_cmd(&shell, host, user, auth, extra_opts, envs, true)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .stderr(Stdio::piped())
@@ -129,12 +192,13 @@ impl SessionReport {
         shell: &Shell,
         host: &str,
         user: &str,
+        auth: &SshAuth,
         extra_opts: &[String],
         envs: &[(String, String)],
         verbose: bool,
     ) -> Command {
-        let null_device = if cfg!(windows) { "NUL" } else { "/dev/null" };
-        let known_hosts = format!("UserKnownHostsFile={null_device}");
+        let known_hosts = format!("UserKnownHostsFile={}", auth.known_hosts.display());
+        let identity = auth.identity.display().to_string();
         let connect_timeout = format!("ConnectTimeout={}", CONNECT_TIMEOUT.as_secs());
         let verbose = verbose.then_some("-v");
         let extra_opts: Vec<String> = extra_opts
@@ -145,7 +209,7 @@ impl SessionReport {
 
         let mut command: Command = cmd!(
             shell,
-            "ssh -T -F none -o BatchMode=yes -o StrictHostKeyChecking=no -o {known_hosts} -o {connect_timeout} {verbose...} {extra_opts...} {destination}"
+            "ssh -T -F none -o BatchMode=yes -o StrictHostKeyChecking=yes -o {known_hosts} -o IdentitiesOnly=yes -i {identity} -o {connect_timeout} {verbose...} {extra_opts...} {destination}"
         )
             .into();
         command.envs(
@@ -486,6 +550,21 @@ impl Drop for Serial {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_mac_from_board_info() {
+        let output = "Chip type:         esp32c6 (revision v0.1)\n\
+            Crystal frequency: 40 MHz\n\
+            Flash size:        4MB\n\
+            MAC address:       98:a3:16:96:8c:08\n";
+        assert_eq!(
+            Mac::parse(output).unwrap().into_inner(),
+            [0x98, 0xa3, 0x16, 0x96, 0x8c, 0x08]
+        );
+        assert!(Mac::parse("Chip type: esp32c6\n").is_err());
+        assert!(Mac::parse("MAC address: 98:a3:16\n").is_err());
+        assert!(Mac::parse("MAC address: 98:a3:16:96:8c:08:ff\n").is_err());
+    }
 
     #[test]
     fn echo_split_across_reads() {

--- a/xtask/src/host.rs
+++ b/xtask/src/host.rs
@@ -5,12 +5,11 @@
 //! The host side of the device communication.
 
 use crate::util::retry_until;
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use quick_xml::escape::escape;
 use std::io::Write;
 use std::net::{TcpStream, ToSocketAddrs};
 use std::time::Duration;
-use strip_ansi_escapes::strip_str;
 use xshell::{Shell, cmd};
 
 /// The device access point.
@@ -25,27 +24,6 @@ impl AccessPoint {
     pub const REACHABLE_TIMEOUT: Duration = Duration::from_mins(1);
     pub const REJOIN_INTERVAL: Duration = Duration::from_secs(8);
     pub const TCP_CONNECT_INTERVAL: Duration = Duration::from_millis(500);
-
-    /// Parses the credentials for the access point out of the capture.
-    pub fn parse<S: AsRef<str>>(lines: &[S]) -> Result<AccessPoint> {
-        let find_field = |key: &str| {
-            lines
-                .iter()
-                .rev()
-                .find_map(|line| {
-                    strip_str(line.as_ref())
-                        .split_once(key)
-                        .map(|(_, value)| value.trim().to_string())
-                })
-                .filter(|value| !value.is_empty())
-                .ok_or_else(|| anyhow!("field `{key}` not found"))
-        };
-
-        Ok(AccessPoint {
-            ssid: find_field("WIFI SSID: ")?,
-            psk: find_field("WIFI PSK: ")?,
-        })
-    }
 
     /// Joins the access point with the ssid and psk. The `interface` can optionally be
     /// specified on multi interface hosts to avoid automatically detecting. It is
@@ -187,31 +165,6 @@ impl AccessPoint {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cmd;
-
-    #[test]
-    fn reads_access_point_off_console() {
-        // This is exactly like esp-println would write.
-        let lines = [
-            "\u{1b}[32mINFO - WIFI SSID: ssh-stamp\u{1b}[0m".to_string(),
-            "\u{1b}[32mINFO - WIFI PSK: stale-before-reflash\u{1b}[0m".to_string(),
-            format!(
-                "INFO - @BENCH checkpoint={} t_us=2700000",
-                cmd::TCP_LISTENING
-            ),
-            "\u{1b}[32mINFO - WIFI SSID: ssh-stamp\u{1b}[0m".to_string(),
-            "\u{1b}[32mINFO - WIFI PSK: password\u{1b}[0m".to_string(),
-        ];
-        let ap = AccessPoint::parse(&lines).unwrap();
-        assert_eq!(ap.ssid, "ssh-stamp");
-        assert_eq!(ap.psk, "password");
-    }
-
-    #[test]
-    fn no_credentials_in_capture_fails_parse() {
-        assert!(AccessPoint::parse(&["INFO - HSM: accepting TCP on port 22"]).is_err());
-        assert!(AccessPoint::parse(&["INFO - WIFI SSID: ssh-stamp"]).is_err());
-    }
 
     #[test]
     fn profile_expected_value() {

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -15,6 +15,7 @@ mod cmd;
 mod device;
 mod elf;
 mod host;
+mod provision;
 mod record;
 mod results;
 mod stack_probe;

--- a/xtask/src/provision.rs
+++ b/xtask/src/provision.rs
@@ -1,0 +1,183 @@
+// SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! This provisions device config on from the host, which is used to
+//! deterministically specify the AP config.
+
+use crate::device::SshAuth;
+use crate::host::AccessPoint;
+use anyhow::{Context, Result, anyhow, bail};
+use embedded_storage_inmemory::MemFlash;
+use getrandom::fill;
+use ssh_key::LineEnding;
+use ssh_key::private::{Ed25519Keypair, KeypairData, PrivateKey};
+use ssh_key::public::{Ed25519PublicKey, KeyData, PublicKey};
+use ssh_stamp::config::{SSHStampConfig, UartPins};
+use ssh_stamp::store::{self, CONFIG_AREA_SIZE, CONFIG_OFFSET};
+use std::fs;
+use std::io::Write;
+#[cfg(unix)]
+use std::os::unix::fs::OpenOptionsExt;
+use std::path::{Path, PathBuf};
+use sunset::SignKey;
+use sunset::packets::Ed25519PubKey;
+use sunset::sshwire::Blob;
+use tempfile::{TempDir, tempdir};
+
+/// This is an in-memory version of the flash area that the firmware would write.
+type ImageFlash = MemFlash<{ CONFIG_OFFSET + CONFIG_AREA_SIZE }, CONFIG_AREA_SIZE, 4>;
+
+/// The per-run identity that a provisioned device boots with.
+pub struct Provision {
+    /// The access point config.
+    access_point: AccessPoint,
+    /// The `app_config` image.
+    image: PathBuf,
+    /// The `known_hosts` file.
+    known_hosts: PathBuf,
+    /// The client private key.
+    identity: PathBuf,
+    /// Holds files until dropped.
+    _dir: TempDir,
+}
+
+impl Provision {
+    /// Creates credentials for the device deterministically by provisioning the
+    /// SSID and password.
+    pub fn generate(host: &str, mac: [u8; 6], uart_pins: UartPins) -> Result<Self> {
+        let mut config =
+            SSHStampConfig::new(mac, uart_pins).map_err(|e| anyhow!("could not provision: {e}"))?;
+
+        // Create a dedicated keypair for the ssh connection.
+        let client = Self::client_keypair()?;
+        config.pubkeys[0] = Some(Ed25519PubKey {
+            key: Blob(client.public.0),
+        });
+        // The client key is already enrolled, so no first-login window.
+        config.first_login = false;
+
+        let access_point = AccessPoint {
+            ssid: config.wifi_ap_ssid.as_str().to_string(),
+            psk: config.wifi_ap_pw.as_str().to_string(),
+        };
+
+        let dir = tempdir().context("could not create provisioning directory")?;
+        let image = dir.path().join("app_config.bin");
+        fs::write(&image, Self::config_image(&config)?).context("could not write config image")?;
+
+        // This allows the ssh connection to trust a known host, i.e. the board itself.
+        let known_hosts = dir.path().join("known_hosts");
+        fs::write(&known_hosts, Self::known_hosts_line(host, &config)?)
+            .context("could not write known_hosts")?;
+
+        // Write the private key so that the follow up ssh connections can use it.
+        let identity = dir.path().join("id_ed25519");
+        Self::write_private_key(&identity, client)?;
+
+        Ok(Provision {
+            access_point,
+            image,
+            known_hosts,
+            identity,
+            _dir: dir,
+        })
+    }
+
+    /// Get the access point from the provisioning.
+    pub fn access_point(&self) -> &AccessPoint {
+        &self.access_point
+    }
+
+    /// The `app_config` partition image to flash.
+    pub fn image(&self) -> &Path {
+        &self.image
+    }
+
+    /// The pinned settings for the SSH sessions of this run.
+    pub fn ssh_auth(&self) -> SshAuth {
+        SshAuth {
+            known_hosts: self.known_hosts.clone(),
+            identity: self.identity.clone(),
+        }
+    }
+
+    /// Generate a new Ed25519 keypair.
+    pub fn client_keypair() -> Result<Ed25519Keypair> {
+        let mut seed = [0u8; 32];
+        fill(&mut seed).map_err(|e| anyhow!("could not generate the keypair: {e}"))?;
+        Ok(Ed25519Keypair::from_seed(&seed))
+    }
+
+    /// Serializes the `config` in order to write to the board, exactly like the board
+    /// would format it.
+    pub fn config_image(config: &SSHStampConfig) -> Result<Vec<u8>> {
+        let mut flash = Box::new(ImageFlash::new(0xFF));
+
+        let mut buf = [0u8; CONFIG_AREA_SIZE];
+        store::save(flash.as_mut(), &mut buf, config)
+            .map_err(|e| anyhow!("could not serialize config: {e}"))?;
+
+        Ok(flash.mem[CONFIG_OFFSET..].to_vec())
+    }
+
+    /// Format the `known_hosts` line that allows the host to trust the firmware board.
+    pub fn known_hosts_line(host: &str, config: &SSHStampConfig) -> Result<String> {
+        let SignKey::Ed25519(key) = &config.hostkey else {
+            bail!("the host key is not Ed25519");
+        };
+        let public = PublicKey::new(
+            KeyData::Ed25519(Ed25519PublicKey(key.verifying_key().to_bytes())),
+            "",
+        );
+
+        Ok(format!("{host} {}\n", public.to_openssh()?))
+    }
+
+    /// Writes the client private key in the format that OpenSSH will use to connect
+    /// to the device.
+    pub fn write_private_key(path: &Path, keypair: Ed25519Keypair) -> Result<()> {
+        let key = PrivateKey::new(KeypairData::Ed25519(keypair), "")?;
+
+        let mut options = fs::OpenOptions::new();
+        options.write(true).create_new(true);
+        // ssh refuses a key that other users can read, so create it as 0600.
+        #[cfg(unix)]
+        options.mode(0o600);
+
+        options
+            .open(path)
+            .context("could not create the client key")?
+            .write_all(key.to_openssh(LineEnding::LF)?.as_bytes())
+            .context("could not write the client key")?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ssh_stamp::store::load;
+
+    #[test]
+    fn create_image_like_firmware_would() {
+        let mac = [0x98, 0xa3, 0x16, 0x96, 0x8c, 0x08];
+        let provision =
+            Provision::generate("192.168.4.1", mac, UartPins { rx: 10, tx: 11 }).unwrap();
+        let image = fs::read(provision.image()).unwrap();
+        assert_eq!(image.len(), CONFIG_AREA_SIZE);
+
+        let mut flash = Box::new(ImageFlash::new(0xFF));
+        flash.mem[CONFIG_OFFSET..].copy_from_slice(&image);
+        let mut buf = [0u8; CONFIG_AREA_SIZE];
+        let config = load(flash.as_mut(), &mut buf).unwrap();
+
+        assert!(!config.first_login);
+        assert!(config.pubkeys[0].is_some());
+        assert_eq!(config.wifi_ap_ssid.as_str(), provision.access_point.ssid);
+        assert_eq!(config.wifi_ap_pw.as_str(), provision.access_point.psk);
+        assert_eq!(config.uart_pins, UartPins { rx: 10, tx: 11 });
+        assert_eq!(config.mac, mac);
+    }
+}


### PR DESCRIPTION
Closes #137 

### Changes
* Write the flash directly on to the board from the xtask, so that the xtask always knows what it's getting from the firmware.
* Use the known hosts file for ssh connections.