### PR TITLE
Add embedded HIL tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,10 @@ jobs:
       # linted too, not just what the esp32c6-devkitc build compiles.
       - name: Clippy
         run: cargo xtask ${{ matrix.target.name }} clippy --release -- -D warnings
+      # Nothing can depend on a test crate, so the HIL crate is never part of the
+      # dependency graph, which is why linting it is run separately.
+      - name: Clippy HIL tests
+        run: cargo xtask ${{ matrix.target.name }} clippy --release -p ssh-stamp-esp32-hil --tests -- -D warnings
       # Also apply clippy to all features for the boards, to make sure that
       # everything gets linted.
       - name: Clippy with extra features.
@@ -88,7 +92,7 @@ jobs:
       # lints every host crate instead, the default set already includes
       # xtask and ota.
       - name: Clippy host crates
-        run: cargo clippy --all-targets --features ota/std -- -D warnings
+        run: cargo clippy --all-targets --features ota/std,can,ipv6,mem-probe -- -D warnings
       - name: Format
         run: cargo fmt --all -- --check
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,7 +3695,6 @@ dependencies = [
  "embassy-sync 0.8.0",
  "embedded-io-async 0.7.0",
  "embedded-test",
- "esp-bootloader-esp-idf",
  "esp-hal",
  "esp-rtos",
  "ssh-stamp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
+dependencies = [
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -735,6 +745,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -765,6 +788,17 @@ dependencies = [
  "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
+dependencies = [
+ "darling_core 0.24.1",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1242,6 +1276,37 @@ checksum = "4f9d62933faa560308e912c975da0f5364b6ccd0f10fa675c5071023226986c9"
 dependencies = [
  "embedded-storage",
  "embedded-storage-async",
+]
+
+[[package]]
+name = "embedded-test"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993ee0ececc2e165add044732d49623150700c3580b6c8eb939aad683abb8eb7"
+dependencies = [
+ "embassy-executor",
+ "embedded-test-linker-script",
+ "embedded-test-macros",
+ "semihosting",
+]
+
+[[package]]
+name = "embedded-test-linker-script"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "892fd6c812db2dc4fde8cac39717b772661bb26b24cd54cb5d6d89b37b5cd8c2"
+
+[[package]]
+name = "embedded-test-macros"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a43a1999a9c78129858244a7ca84c136f2c1f4a2518565793b35fae2ab104b72"
+dependencies = [
+ "darling 0.24.1",
+ "proc-macro-error3",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2923,6 +2988,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error-attr3"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error3"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
+dependencies = [
+ "proc-macro-error-attr3",
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3598,6 +3684,25 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "toml",
+]
+
+[[package]]
+name = "ssh-stamp-esp32-hil"
+version = "0.1.0"
+dependencies = [
+ "embassy-executor",
+ "embassy-futures",
+ "embassy-sync 0.8.0",
+ "embedded-io-async 0.7.0",
+ "embedded-test",
+ "esp-bootloader-esp-idf",
+ "esp-hal",
+ "esp-rtos",
+ "ssh-stamp",
+ "ssh-stamp-esp32",
+ "ssh-stamp-esp32-boards",
+ "ssh-stamp-hal",
+ "sunset",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Roman Valls, 2025
+# SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -21,6 +22,7 @@ members = [
     "ssh-stamp-hal",
     "ssh-stamp-esp32",
     "ssh-stamp-esp32-boards",
+    "ssh-stamp-esp32-hil",
     "ota",
     "xtask",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -181,7 +181,9 @@ opt-level = "s"
 
 [features]
 default = []
-ipv6 = []
+
+# Enables IPv6 addressing.
+ipv6 = ["embassy-net/proto-ipv6"]
 
 # Enables the SFTP OTA Subsystem. Use packer to pack a binary and PUT it over sftp
 sftp-ota = ["ota/sftp"]

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,0 +1,54 @@
+<!--
+SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+Testing for ssh-stamp comes in two forms, unit tests and HIL tests. 
+
+# Unit tests
+
+The [`ota`](../ota), [`xtask`](../xtask) and parts of the [`ssh-stamp`](../src) core
+library have unit tests. These can be run directly on the host:
+
+```sh
+cargo test
+```
+
+# HIL tests
+
+There is also a set of HIL tests that require an ESP32 board to run. These
+are built on the [embedded-test] framework as part of the
+[ssh-stamp-esp32-hil](../ssh-stamp-esp32-hil) crate. Each file under the 
+`tests/`directory there compiles it's own test binary, which is flashed by
+probe-rs and run.
+
+[embedded-test]: https://crates.io/crates/embedded-test
+
+## Requirements
+
+- The probe-rs CLI: `cargo install probe-rs-tools`.
+- A debug connection to the chip.
+
+## Running
+
+```sh
+cargo xtask esp32c6-devkitc test
+```
+
+Any board or chip target that `cargo xtask` accepts works in place of
+`esp32c6-devkitc`. The tests always build with the release profile.
+
+## Effects on the board
+
+- Running the tests replaces the application in flash, reflash the
+  firmware afterwards: `cargo xtask <board> run`.
+- `tests/flash.rs` overwrites the stored config sector. This test accepts
+  chip targets as well as board targets.
+- `tests/uart.rs` uses the board's UART TX pin, looped back into the RX
+  internally. This test only accepts board targets.
+
+## Adding tests
+
+Each `tests/*.rs` file is a separate flash and run. A new file needs a
+`[[test]]` entry with `harness = false` in `Cargo.toml`.

--- a/ssh-stamp-esp32-hil/Cargo.toml
+++ b/ssh-stamp-esp32-hil/Cargo.toml
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+[package]
+name = "ssh-stamp-esp32-hil"
+version = "0.1.0"
+edition = "2024"
+authors = ["Marko Malenic <mmalenic1@gmail.com>"]
+description = "HIL tests for ssh-stamp"
+license = "GPL-3.0-or-later"
+repository = "https://github.com/brainstorm/ssh-stamp"
+publish = false
+
+# embedded-test needs it's own harness, so this must be disabled.
+[lib]
+test = false
+doctest = false
+bench = false
+
+[[test]]
+name = "flash"
+harness = false
+
+# The uart tests require a real board definition, so it's only enabled
+# if a board feature is enabled.
+[[test]]
+name = "uart"
+harness = false
+required-features = ["board-any"]
+
+[dependencies]
+ssh-stamp = { path = "..", default-features = false }
+ssh-stamp-esp32 = { path = "../ssh-stamp-esp32", default-features = false, features = [
+    "bench-loopback",
+] }
+ssh-stamp-esp32-boards = { path = "../ssh-stamp-esp32-boards", optional = true }
+ssh-stamp-hal = { path = "../ssh-stamp-hal" }
+
+embedded-test = { version = "0.7", features = ["embassy-010", "external-executor"] }
+embassy-executor = { workspace = true }
+
+esp-hal = { workspace = true }
+esp-rtos = { version = "0.3", features = ["embassy"] }
+esp-bootloader-esp-idf = { version = "0.5" }
+
+embassy-futures = { workspace = true }
+embassy-sync = { workspace = true }
+embedded-io-async = { workspace = true }
+sunset = { workspace = true }
+
+[features]
+default = []
+
+# The reason board-any exists is to ensure that the `uart` [[test]] can be selected
+# for only when a board is also enabled. Regular chip libraries can't run this test,
+# and there's no other way to specify any board for enabling the `uart` test.
+board-any = ["dep:ssh-stamp-esp32-boards"]
+
+# The board features require specifying a real board with a definition.
+board-esp32c5-devkitc = ["ssh-stamp-esp32/board-esp32c5-devkitc", "board-any", "esp32c5"]
+board-esp32c61-devkitc = ["ssh-stamp-esp32/board-esp32c61-devkitc", "board-any", "esp32c61"]
+board-esp32c6-devkitc = ["ssh-stamp-esp32/board-esp32c6-devkitc", "board-any", "esp32c6"]
+board-esp32-s2-saola = ["ssh-stamp-esp32/board-esp32-s2-saola", "board-any", "esp32s2"]
+board-waveshare-esp32-s3-touch-lcd-43 = [
+    "ssh-stamp-esp32/board-waveshare-esp32-s3-touch-lcd-43",
+    "board-any",
+    "esp32s3",
+]
+
+
+# These are the lib only features for tests that don't need a real board definition.
+# The Xtensa chips also require the embedded-test semihosting feature.
+esp32 = ["ssh-stamp-esp32/esp32", "embedded-test/xtensa-semihosting"]
+esp32c2 = ["ssh-stamp-esp32/esp32c2"]
+esp32c3 = ["ssh-stamp-esp32/esp32c3"]
+esp32c5 = ["ssh-stamp-esp32/esp32c5"]
+esp32c6 = ["ssh-stamp-esp32/esp32c6"]
+esp32c61 = ["ssh-stamp-esp32/esp32c61"]
+esp32s2 = ["ssh-stamp-esp32/esp32s2", "embedded-test/xtensa-semihosting"]
+esp32s3 = ["ssh-stamp-esp32/esp32s3", "embedded-test/xtensa-semihosting"]
+
+[lints]
+workspace = true

--- a/ssh-stamp-esp32-hil/Cargo.toml
+++ b/ssh-stamp-esp32-hil/Cargo.toml
@@ -42,7 +42,6 @@ embassy-executor = { workspace = true }
 
 esp-hal = { workspace = true }
 esp-rtos = { version = "0.3", features = ["embassy"] }
-esp-bootloader-esp-idf = { version = "0.5" }
 
 embassy-futures = { workspace = true }
 embassy-sync = { workspace = true }

--- a/ssh-stamp-esp32-hil/build.rs
+++ b/ssh-stamp-esp32-hil/build.rs
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+fn main() {
+    // Based on the embedded-test examples and documentation.
+    // See: <https://crates.io/crates/embedded-test>
+    println!("cargo::rustc-check-cfg=cfg(rust_analyzer)");
+    println!("cargo:rustc-link-arg=-Tembedded-test.x");
+    println!("cargo:rustc-link-arg=-Tlinkall.x");
+}

--- a/ssh-stamp-esp32-hil/src/lib.rs
+++ b/ssh-stamp-esp32-hil/src/lib.rs
@@ -15,8 +15,5 @@
 
 #![no_std]
 
-// The application descriptor the esp-idf bootloader expects in the app image.
-esp_bootloader_esp_idf::esp_app_desc!();
-
 // The `getrandom` custom backend.
 ssh_stamp_esp32::getrandom_backend!();

--- a/ssh-stamp-esp32-hil/src/lib.rs
+++ b/ssh-stamp-esp32-hil/src/lib.rs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The HIL tests for ssh-stamp.
+//!
+//! Each file under `tests/` is an [embedded-test] binary which uses probe-rs
+//! to flash the image and execute the test. These should be run through xtask:
+//!
+//! ```sh
+//! cargo xtask esp32c6-devkitc test
+//! ```
+//!
+//! [embedded-test]: https://github.com/probe-rs/embedded-test
+
+#![no_std]
+
+// The application descriptor the esp-idf bootloader expects in the app image.
+esp_bootloader_esp_idf::esp_app_desc!();
+
+// The `getrandom` custom backend.
+ssh_stamp_esp32::getrandom_backend!();

--- a/ssh-stamp-esp32-hil/tests/flash.rs
+++ b/ssh-stamp-esp32-hil/tests/flash.rs
@@ -13,7 +13,6 @@ use ssh_stamp_esp32_hil as _;
 #[embedded_test::tests(default_timeout = 30, executor = esp_rtos::embassy::Executor::new())]
 mod tests {
     use ssh_stamp::config::UartPins;
-    use ssh_stamp::store;
     use ssh_stamp::store::{create, load};
     use ssh_stamp_esp32::{EntropySource, get_flash_n_buffer, boot};
 
@@ -49,7 +48,12 @@ mod tests {
         assert_eq!(loaded.uart_pins, UartPins { rx: 10, tx: 11 });
         assert_eq!(loaded.wifi_ap_ssid, created.wifi_ap_ssid);
         // Avoid using assert_eq to not show any PSK or secret values on failure.
-        #[allow(clippy::manual_assert_eq)]
-        assert!(created == loaded);
+        // Block-scoped because this is inside a macro invocation and would otherwise
+        // be ignored. `unknown_lints` is allowed because the esp toolchain's clippy
+        // predates `manual_assert_eq`.
+        #[allow(unknown_lints, clippy::manual_assert_eq)]
+        {
+            assert!(created == loaded);
+        }
     }
 }

--- a/ssh-stamp-esp32-hil/tests/flash.rs
+++ b/ssh-stamp-esp32-hil/tests/flash.rs
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The hardware device tests for the flash config storage.
+
+#![no_std]
+#![no_main]
+
+// Links the HIL library crate for the bootloader and getrandom initialization.
+use ssh_stamp_esp32_hil as _;
+
+#[embedded_test::tests(default_timeout = 30, executor = esp_rtos::embassy::Executor::new())]
+mod tests {
+    use ssh_stamp::config::UartPins;
+    use ssh_stamp::store;
+    use ssh_stamp::store::{create, load};
+    use ssh_stamp_esp32::{EntropySource, get_flash_n_buffer, boot};
+
+    /// The test init state.
+    pub struct Context {
+        _entropy_source: EntropySource,
+    }
+
+    #[init]
+    fn init() -> Context {
+        boot!(_peripherals, _rng, entropy_source, _sw_int1);
+
+        Context {
+            _entropy_source: entropy_source,
+        }
+    }
+
+    #[test]
+    async fn config_flash_create_load(_context: Context) {
+        let flash_guard = get_flash_n_buffer().expect("flash was initialised in init");
+        let mut fb = flash_guard.lock().await;
+        let (flash, buf) = fb.split_ref_mut();
+
+        // Define a test mac to avoid confusion with any real board.
+        let mac = [0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
+        let pins = UartPins { rx: 10, tx: 11 };
+
+        let created =
+            create(flash, buf, mac, pins).expect("saving a config");
+        let loaded = load(flash, buf).expect("reading the config back");
+
+        assert_eq!(loaded.mac, mac);
+        assert_eq!(loaded.uart_pins, UartPins { rx: 10, tx: 11 });
+        assert_eq!(loaded.wifi_ap_ssid, created.wifi_ap_ssid);
+        // Avoid using assert_eq to not show any PSK or secret values on failure.
+        #[allow(clippy::manual_assert_eq)]
+        assert!(created == loaded);
+    }
+}

--- a/ssh-stamp-esp32-hil/tests/flash.rs
+++ b/ssh-stamp-esp32-hil/tests/flash.rs
@@ -14,7 +14,7 @@ use ssh_stamp_esp32_hil as _;
 mod tests {
     use ssh_stamp::config::UartPins;
     use ssh_stamp::store::{create, load};
-    use ssh_stamp_esp32::{EntropySource, get_flash_n_buffer, boot};
+    use ssh_stamp_esp32::{EntropySource, boot, get_flash_n_buffer};
 
     /// The test init state.
     pub struct Context {
@@ -40,8 +40,7 @@ mod tests {
         let mac = [0x02, 0x03, 0x04, 0x05, 0x06, 0x07];
         let pins = UartPins { rx: 10, tx: 11 };
 
-        let created =
-            create(flash, buf, mac, pins).expect("saving a config");
+        let created = create(flash, buf, mac, pins).expect("saving a config");
         let loaded = load(flash, buf).expect("reading the config back");
 
         assert_eq!(loaded.mac, mac);

--- a/ssh-stamp-esp32-hil/tests/uart.rs
+++ b/ssh-stamp-esp32-hil/tests/uart.rs
@@ -8,6 +8,8 @@
 #![no_std]
 #![no_main]
 
+use core::future::{Future, ready};
+
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::pipe::Pipe;
 
@@ -41,8 +43,8 @@ impl embedded_io_async::Write for ChanWrite<'_> {
         Ok(self.0.write(buf).await)
     }
 
-    async fn flush(&mut self) -> Result<(), Self::Error> {
-        Ok(())
+    fn flush(&mut self) -> impl Future<Output = Result<(), Self::Error>> {
+        ready(Ok(()))
     }
 }
 

--- a/ssh-stamp-esp32-hil/tests/uart.rs
+++ b/ssh-stamp-esp32-hil/tests/uart.rs
@@ -49,13 +49,15 @@ impl embedded_io_async::Write for ChanWrite<'_> {
 #[embedded_test::tests(default_timeout = 30, executor = esp_rtos::embassy::Executor::new())]
 mod tests {
     use super::{ChanRead, ChanWrite};
+    use core::array::from_fn;
     use embassy_futures::select::{Either, select};
     use embassy_sync::pipe::Pipe;
     use ssh_stamp::serial::serial_bridge;
-    use ssh_stamp_esp32::{BufferedUart, EspUartPins, UART_SIGNAL, spawn_uart, start_interrupt_executor, boot};
+    use ssh_stamp_esp32::{
+        BufferedUart, EspUartPins, UART_SIGNAL, boot, spawn_uart, start_interrupt_executor,
+    };
     use ssh_stamp_esp32_boards::take_uart_pins;
     use ssh_stamp_hal::UartParams;
-    use core::array::from_fn;
 
     pub struct Context {
         uart_buf: &'static BufferedUart,

--- a/ssh-stamp-esp32-hil/tests/uart.rs
+++ b/ssh-stamp-esp32-hil/tests/uart.rs
@@ -1,0 +1,124 @@
+// SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The hardware tests for the UART code which runs against a UART peripheral with its
+//! TX looped back into the RX through the GPIOs.
+
+#![no_std]
+#![no_main]
+
+use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
+use embassy_sync::pipe::Pipe;
+
+// Links the HIL library crate for the bootloader and getrandom initialization.
+use ssh_stamp_esp32_hil as _;
+
+/// Mock the channel read required on the [`serial_bridge`], this will move the bytes
+/// through the pipe.
+struct ChanRead<'a>(&'a Pipe<CriticalSectionRawMutex, 512>);
+
+impl embedded_io_async::ErrorType for ChanRead<'_> {
+    type Error = sunset::Error;
+}
+
+impl embedded_io_async::Read for ChanRead<'_> {
+    async fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        Ok(self.0.read(buf).await)
+    }
+}
+
+/// Mock the channel write required on the [`serial_bridge`], this will move the bytes
+/// through the pipe.
+struct ChanWrite<'a>(&'a Pipe<CriticalSectionRawMutex, 512>);
+
+impl embedded_io_async::ErrorType for ChanWrite<'_> {
+    type Error = sunset::Error;
+}
+
+impl embedded_io_async::Write for ChanWrite<'_> {
+    async fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        Ok(self.0.write(buf).await)
+    }
+
+    async fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+#[embedded_test::tests(default_timeout = 30, executor = esp_rtos::embassy::Executor::new())]
+mod tests {
+    use super::{ChanRead, ChanWrite};
+    use embassy_futures::select::{Either, select};
+    use embassy_sync::pipe::Pipe;
+    use ssh_stamp::serial::serial_bridge;
+    use ssh_stamp_esp32::{BufferedUart, EspUartPins, UART_SIGNAL, spawn_uart, start_interrupt_executor, boot};
+    use ssh_stamp_esp32_boards::take_uart_pins;
+    use ssh_stamp_hal::UartParams;
+    use core::array::from_fn;
+
+    pub struct Context {
+        uart_buf: &'static BufferedUart,
+    }
+
+    async fn read_bytes(mut read: impl AsyncFnMut(&mut [u8]) -> usize, buf: &mut [u8]) {
+        let mut filled = 0;
+        while filled < buf.len() {
+            filled += read(&mut buf[filled..]).await;
+        }
+    }
+
+    #[init]
+    fn init() -> Context {
+        boot!(peripherals, _rng, _entropy_source, sw_int1);
+
+        let (rx_pin, tx_pin, _rx_num, _tx_num) = take_uart_pins!(peripherals);
+        let pins = EspUartPins {
+            rx: rx_pin,
+            tx: tx_pin,
+        };
+
+        let spawner = start_interrupt_executor(sw_int1);
+        let uart_buf = spawn_uart(spawner, peripherals.UART1, pins, UartParams::default());
+        UART_SIGNAL.signal(0);
+
+        Context { uart_buf }
+    }
+
+    #[test]
+    async fn write_bytes_through_uart(context: Context) {
+        let uart_buf = context.uart_buf;
+
+        let sent: [u8; 256] = from_fn(|i| u8::try_from(i).unwrap());
+        uart_buf.write(&sent).await;
+
+        let mut received = [0u8; 256];
+        read_bytes(async |buf| uart_buf.read(buf).await, &mut received).await;
+
+        assert_eq!(received, sent);
+        assert_eq!(uart_buf.check_dropped_bytes(), 0);
+    }
+
+    #[test]
+    async fn serial_bridge_ssh_bytes(context: Context) {
+        let uart_buf = context.uart_buf;
+
+        let to_uart: Pipe<_, 512> = Pipe::new();
+        let from_uart: Pipe<_, 512> = Pipe::new();
+        let bridge = serial_bridge(ChanRead(&to_uart), ChanWrite(&from_uart), uart_buf);
+
+        let receive_function = async {
+            to_uart.write_all(b"test").await;
+
+            let mut received = [0u8; 4];
+            read_bytes(async |buf| from_uart.read(buf).await, &mut received).await;
+            received
+        };
+
+        // Run the bridge until the receive function finishes.
+        match select(bridge, receive_function).await {
+            Either::First(result) => panic!("the bridge stopped on its own: {result:?}"),
+            Either::Second(received) => assert_eq!(received.as_slice(), b"test"),
+        }
+    }
+}

--- a/ssh-stamp-esp32/Cargo.toml
+++ b/ssh-stamp-esp32/Cargo.toml
@@ -12,6 +12,20 @@ description = "ESP32 implementation of the ssh-stamp-hal traits and bootable bin
 license = "GPL-3.0-or-later"
 repository = "https://github.com/brainstorm/ssh-stamp"
 
+# This crate is no_std, and because libtest pulls in std, it will never be valid to
+# compile them. Disabling here means `--tests` will work correctly in the current
+# multi-crate setup.
+[lib]
+test = false
+doctest = false
+bench = false
+
+[[bin]]
+name = "ssh-stamp-esp32"
+path = "src/bin/ssh-stamp-esp32.rs"
+test = false
+bench = false
+
 [dependencies]
 ssh-stamp = { path = "..", default-features = false }
 ssh-stamp-hal = { path = "../ssh-stamp-hal" }

--- a/ssh-stamp-esp32/src/bin/ssh-stamp-esp32.rs
+++ b/ssh-stamp-esp32/src/bin/ssh-stamp-esp32.rs
@@ -28,11 +28,7 @@
 extern crate alloc;
 
 use embassy_executor::Spawner;
-use esp_hal::interrupt::{Priority, software::SoftwareInterruptControl};
-#[cfg(not(any(feature = "esp32c5", feature = "esp32c61")))]
-use esp_hal::rng::{Trng, TrngSource};
 use esp_println::logger;
-use esp_rtos::embassy::InterruptExecutor;
 use heapless::String;
 use log::{debug, error, warn};
 use ssh_stamp::config::{SSHStampConfig, UartPins};
@@ -41,13 +37,13 @@ use ssh_stamp::store;
 use ssh_stamp::{
     app,
     mem_probe::{self, Checkpoint},
-    settings::{DEFAULT_IP, HEAP_SIZE},
+    settings::DEFAULT_IP,
 };
 #[cfg(feature = "can")]
 use ssh_stamp_esp32::{BufferedCan, CAN_BUF, EspCanPins, can_task};
 use ssh_stamp_esp32::{
-    BufferedUart, EspPlatform, EspUartPins, EspWifi, UART_BUF, bench, flash, mac_address,
-    register_custom_rng, uart_task,
+    EspPlatform, EspUartPins, EspWifi, bench, entropy_source_active, flash, mac_address,
+    spawn_uart, start_interrupt_executor,
 };
 use ssh_stamp_esp32_boards::Board;
 use ssh_stamp_hal::{HalError, WifiError};
@@ -55,83 +51,13 @@ use ssh_stamp_hal::{NetworkProviderHal, WifiHal};
 use static_cell::StaticCell;
 use sunset_async::SunsetMutex;
 
-cfg_if::cfg_if! {
-    if #[cfg(feature = "esp32")] {
-        use esp_hal::timer::timg::TimerGroup;
-    }
-}
-
-static INT_EXECUTOR: StaticCell<InterruptExecutor<1>> = StaticCell::new(); // 0 is used for esp_rtos
-
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
-    cfg_if::cfg_if!(
-        if #[cfg(feature = "esp32s2")] {
-            // TODO: This heap size will crash at runtime (only for the ESP32S2);
-            // see https://github.com/brainstorm/ssh-stamp/pull/41#issuecomment-2964775170
-            esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: HEAP_SIZE);
-        } else {
-            esp_alloc::heap_allocator!(size: HEAP_SIZE);
-        }
-    );
     esp_bootloader_esp_idf::esp_app_desc!();
     logger::init_logger_from_env();
-    bench::log_heap("boot");
 
     debug!("HSM: initialising peripherals");
-
-    // Note that benches do depend on a stable clock speed across comparisons. The default
-    // shouldn't change much, but theoretically an upgrade could change it.
-    let config = esp_hal::Config::default();
-    let peripherals = esp_hal::init(config);
-
-    // Enable true random number generation using ADC entropy source before config creation.
-    // The ESP32 hardware RNG only produces true random numbers when RF subsystem is enabled
-    // OR ADC entropy source is active. This ensures WiFi password and SSH hostkey use
-    // cryptographically secure random values.
-    // See: https://github.com/brainstorm/ssh-stamp/issues/10
-    // See: https://github.com/esp-rs/esp-hal/pull/3829
-    //
-    // TODO: The ESP32-C5/C61 TRNG is not yet available in esp-hal 1.1.1. Once
-    // https://github.com/esp-rs/esp-hal/pull/4978 lands in a release, remove
-    // this cfg_if! and use Trng/TrngSource unconditionally for all targets.
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32c5", feature = "esp32c61"))] {
-            // ESP32-C5/C61 have no TRNG peripheral — use the basic Rng directly.
-            // Until the TODO above is resolved, key material on these chips is
-            // only as good as the bare RNG register, so say so out loud.
-            warn!("No TRNG on this chip: RNG is not cryptographically secure until the radio is up");
-            let rng = esp_hal::rng::Rng::new();
-            register_custom_rng(rng);
-        } else {
-            // The RNG register only yields true randomness while an entropy
-            // source is active. There are two, and this firmware uses both in
-            // sequence:
-            //
-            //   1. the SAR ADC source enabled here, covering early boot, and
-            //   2. the RF subsystem, once WiFi is up.
-            //
-            // `Trng::downgrade` returns `Rng`, a zero-sized handle that just
-            // reads the register, so it carries no guarantee of its own —
-            // whichever source is live at the time is what decides quality.
-            //
-            // The ADC source must therefore stay enabled until the radio takes
-            // over, because everything minted in between depends on it: the
-            // SSH host key, WiFi SSID/PSK and MAC all come from
-            // `store::load_or_create` and `prepare_ap_config` below. It is
-            // handed over (and explicitly dropped) just before the radio is
-            // initialised — see the drop site further down for why it cannot
-            // simply be left running.
-            let trng_source = TrngSource::new(peripherals.RNG, peripherals.ADC1);
-            let trng = Trng::try_new()
-                .expect("TrngSource was just created, so the TRNG must be available");
-            let rng = trng.downgrade();
-            register_custom_rng(rng);
-        }
-    }
-
-    debug!("Initialising flash");
-    flash::init(peripherals.FLASH);
+    ssh_stamp_esp32::boot!(peripherals, rng, entropy_source, sw_int1);
 
     #[cfg(feature = "sftp-ota")]
     {
@@ -161,11 +87,10 @@ async fn main(spawner: Spawner) -> ! {
     // entropy source enabled above has to still be running. Guard the
     // invariant rather than trusting a comment: `debug-assertions` are on
     // even in release for this workspace, so reintroducing an early drop of
-    // the `TrngSource` fails loudly on the bench instead of silently
+    // the `EntropySource` fails loudly on the bench instead of silently
     // producing predictable keys.
-    #[cfg(not(any(feature = "esp32c5", feature = "esp32c61")))]
     debug_assert!(
-        TrngSource::is_enabled(),
+        entropy_source_active(),
         "entropy source was disabled before host key generation"
     );
 
@@ -197,41 +122,9 @@ async fn main(spawner: Spawner) -> ! {
     static CONFIG: StaticCell<SunsetMutex<SSHStampConfig>> = StaticCell::new();
     let config: &'static SunsetMutex<SSHStampConfig> = CONFIG.init(SunsetMutex::new(flash_config));
 
-    debug!("Initialising timers");
-    let sw_int = SoftwareInterruptControl::new(peripherals.SW_INTERRUPT);
-    cfg_if::cfg_if! {
-       if #[cfg(feature = "esp32")] {
-            // TODO: Test this feature configuration
-            let timg1 = TimerGroup::new(peripherals.TIMG1);
-             esp_rtos::start(timg1.timer0, sw_int.software_interrupt0);
-       } else if #[cfg(any(feature = "esp32s2", feature = "esp32s3"))] {
-            // TODO: Test this feature configuration
-           use esp_hal::timer::systimer::SystemTimer;
-           let systimer = SystemTimer::new(peripherals.SYSTIMER);
-            esp_rtos::start(systimer.alarm0, sw_int.software_interrupt0);
-       } else {
-           use esp_hal::timer::systimer::SystemTimer;
-           let systimer = SystemTimer::new(peripherals.SYSTIMER);
-           esp_rtos::start(systimer.alarm0, sw_int.software_interrupt0);
-       }
-    }
-
     mem_probe::checkpoint(Checkpoint::Boot);
-    let uart_buf = UART_BUF.init_with(BufferedUart::new);
-    let interrupt_executor =
-        INT_EXECUTOR.init_with(|| InterruptExecutor::new(sw_int.software_interrupt1));
-    cfg_if::cfg_if! {
-        if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
-            let interrupt_spawner = interrupt_executor.start(Priority::Priority3);
-        } else if #[cfg(feature = "esp32c6")] {
-            let interrupt_spawner = interrupt_executor.start(Priority::Priority10);
-        } else {
-            let interrupt_spawner = interrupt_executor.start(Priority::Priority1);
-        }
-    }
-    interrupt_spawner.spawn(
-        uart_task(uart_buf, peripherals.UART1, pins, uart_params).expect("uart_task spawn failed"),
-    );
+    let interrupt_spawner = start_interrupt_executor(sw_int1);
+    let uart_buf = spawn_uart(interrupt_spawner, peripherals.UART1, pins, uart_params);
 
     #[cfg(feature = "can")]
     let can_buf: &'static BufferedCan = {
@@ -266,24 +159,13 @@ async fn main(spawner: Spawner) -> ! {
         .await
         .expect("Failed to prepare AP config");
 
-    // Hand the entropy source over to the radio.
-    //
-    // The SAR ADC source cannot simply be left running: Espressif requires it
-    // to be switched off "before RF subsystem features, ADC, or I2S (ESP32
-    // only) are initialized", warning that it "is not safe to use if any other
-    // subsystem is accessing the RF subsystem or the ADC at the same time"
-    // (ESP-IDF, Random Number Generation). It also commandeers the SAR ADC —
-    // and I2S0 on the classic ESP32 — which the radio needs back.
-    //
-    // Nothing is lost by dropping it here: `WifiController::new` inside
-    // `bring_up()` enables the RF subsystem, which is itself an entropy
-    // source, and esp-radio registers that fact with esp-hal. So the SSH
-    // session and key-exchange material sunset draws per connection is still
-    // covered, just by the radio rather than the ADC.
-    //
-    // https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/random.html
-    #[cfg(not(any(feature = "esp32c5", feature = "esp32c61")))]
-    drop(trng_source);
+    // Hand the entropy source over to the radio. The `WifiController::new`
+    // inside `bring_up()` enables the RF subsystem, which is itself an
+    // entropy source, and Espressif requires the ADC source to be off before
+    // the RF subsystem starts. Nothing is lost by dropping it here, the
+    // key-exchange material sunset draws per connection is covered by the
+    // radio from now on.
+    drop(entropy_source);
 
     let mut wifi = EspWifi::new(spawner, peripherals.WIFI, rng, DEFAULT_IP);
     wifi.configure_ap(ap_config)
@@ -312,9 +194,8 @@ async fn main(spawner: Spawner) -> ! {
     // running. sunset draws fresh key-exchange material from `getrandom` for
     // every SSH connection served below, so if this does not hold the handover
     // has a hole in it.
-    #[cfg(not(any(feature = "esp32c5", feature = "esp32c61")))]
     debug_assert!(
-        TrngSource::is_enabled(),
+        entropy_source_active(),
         "no entropy source active after WiFi came up"
     );
 
@@ -326,32 +207,8 @@ async fn main(spawner: Spawner) -> ! {
     esp_hal::system::software_reset();
 }
 
-/// `getrandom` custom backend.
-///
-/// getrandom 0.4 picks its entropy backend by cfg rather than by cargo
-/// feature: every bare-metal target here is built with
-/// `--cfg getrandom_backend="custom"` (see `.cargo/config.toml`), which
-/// makes getrandom link this symbol. It must be defined exactly once in the
-/// whole program, so it lives in the binary — as getrandom's own docs
-/// recommend — and forwards to the hardware TRNG registered at boot by
-/// [`register_custom_rng`].
-///
-/// This is what feeds the SSH host key and the `WiFi` PSK, so it must be a
-/// real entropy source, never a stub.
-#[unsafe(no_mangle)]
-unsafe extern "Rust" fn __getrandom_v03_custom(
-    dest: *mut u8,
-    len: usize,
-) -> Result<(), getrandom::Error> {
-    // SAFETY: getrandom guarantees `dest` is valid for writes of `len`
-    // bytes. The buffer may be uninitialised, so it is zeroed before a
-    // slice is formed over it, as getrandom's documentation prescribes.
-    let buf = unsafe {
-        core::ptr::write_bytes(dest, 0, len);
-        core::slice::from_raw_parts_mut(dest, len)
-    };
-    ssh_stamp_esp32::rng_fill_bytes(buf)
-}
+// The `getrandom` custom backend.
+ssh_stamp_esp32::getrandom_backend!();
 
 #[panic_handler]
 fn panic(_info: &core::panic::PanicInfo) -> ! {

--- a/ssh-stamp-esp32/src/bin/ssh-stamp-esp32.rs
+++ b/ssh-stamp-esp32/src/bin/ssh-stamp-esp32.rs
@@ -28,7 +28,6 @@
 extern crate alloc;
 
 use embassy_executor::Spawner;
-use esp_println::logger;
 use heapless::String;
 use log::{debug, error, warn};
 use ssh_stamp::config::{SSHStampConfig, UartPins};
@@ -53,10 +52,6 @@ use sunset_async::SunsetMutex;
 
 #[esp_rtos::main]
 async fn main(spawner: Spawner) -> ! {
-    esp_bootloader_esp_idf::esp_app_desc!();
-    logger::init_logger_from_env();
-
-    debug!("HSM: initialising peripherals");
     ssh_stamp_esp32::boot!(peripherals, rng, entropy_source, sw_int1);
 
     #[cfg(feature = "sftp-ota")]

--- a/ssh-stamp-esp32/src/boot.rs
+++ b/ssh-stamp-esp32/src/boot.rs
@@ -29,9 +29,9 @@ macro_rules! init_heap {
         // TODO: This heap size will crash at runtime (only for the ESP32S2);
         // see https://github.com/brainstorm/ssh-stamp/pull/41#issuecomment-2964775170
         #[cfg(feature = "esp32s2")]
-        $crate::esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: ::ssh_stamp::settings::HEAP_SIZE);
+        $crate::esp_alloc::heap_allocator!(#[$crate::esp_hal::ram(reclaimed)] size: $crate::ssh_stamp::settings::HEAP_SIZE);
         #[cfg(not(feature = "esp32s2"))]
-        $crate::esp_alloc::heap_allocator!(size: ::ssh_stamp::settings::HEAP_SIZE);
+        $crate::esp_alloc::heap_allocator!(size: $crate::ssh_stamp::settings::HEAP_SIZE);
     };
 }
 
@@ -44,17 +44,17 @@ macro_rules! init_heap {
 #[macro_export]
 macro_rules! start_rtos {
     ($peripherals:ident) => {{
-        let sw_int = ::esp_hal::interrupt::software::SoftwareInterruptControl::new(
+        let sw_int = $crate::esp_hal::interrupt::software::SoftwareInterruptControl::new(
             $peripherals.SW_INTERRUPT,
         );
         #[cfg(feature = "esp32")]
-        ::esp_rtos::start(
-            ::esp_hal::timer::timg::TimerGroup::new($peripherals.TIMG1).timer0,
+        $crate::esp_rtos::start(
+            $crate::esp_hal::timer::timg::TimerGroup::new($peripherals.TIMG1).timer0,
             sw_int.software_interrupt0,
         );
         #[cfg(not(feature = "esp32"))]
-        ::esp_rtos::start(
-            ::esp_hal::timer::systimer::SystemTimer::new($peripherals.SYSTIMER).alarm0,
+        $crate::esp_rtos::start(
+            $crate::esp_hal::timer::systimer::SystemTimer::new($peripherals.SYSTIMER).alarm0,
             sw_int.software_interrupt0,
         );
         sw_int.software_interrupt1
@@ -79,7 +79,7 @@ macro_rules! boot {
 
         // Note that benches do depend on a stable clock speed across comparisons. The default
         // shouldn't change much, but theoretically an upgrade could change it.
-        let $peripherals = ::esp_hal::init(::esp_hal::Config::default());
+        let $peripherals = $crate::esp_hal::init($crate::esp_hal::Config::default());
 
         // Enable true random number generation before the config is created, so
         // the WiFi password and SSH host key have cryptographically secure values.

--- a/ssh-stamp-esp32/src/boot.rs
+++ b/ssh-stamp-esp32/src/boot.rs
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: 2026 Roman Valls Guimera <brainstorm@nopcode.org>
+// SPDX-FileCopyrightText: 2026 Julio Beltran Ortega <jubeormk1@gmail.com>
+// SPDX-FileCopyrightText: 2026 Angus Gratton <gus@projectgus.com>
+// SPDX-FileCopyrightText: 2026 Sergio Gasquez <sergio.gasquez@gmail.com>
+// SPDX-FileCopyrightText: 2026 pancake <pancake@nopcode.org>
+// SPDX-FileCopyrightText: 2026 Gabriel Ku Wei Bin <gabriel.ku@fsfe.org>
+// SPDX-FileCopyrightText: 2026 Anthony Tambasco <anthony.tambasco@fastmail.com>
+// SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+//! The boot sequence macros which are used when initializing the device. These
+//! are separate macros so that they remain testable. Everything that consumes
+//! `Peripherals` must be a macro because fields like `TIMG1` or `SYSTIMER` are
+//! different per-chip, and cannot be resolved in a single function in the
+//! library crate.
+
+use embassy_executor::SendSpawner;
+use esp_hal::interrupt::{Priority, software::SoftwareInterrupt};
+use esp_rtos::embassy::InterruptExecutor;
+use static_cell::StaticCell;
+
+/// Creates the global heap allocator using [`ssh_stamp::settings::HEAP_SIZE`].
+///
+/// The calling crate needs `ssh-stamp` and `esp-hal` as dependencies.
+#[macro_export]
+macro_rules! init_heap {
+    () => {
+        // TODO: This heap size will crash at runtime (only for the ESP32S2);
+        // see https://github.com/brainstorm/ssh-stamp/pull/41#issuecomment-2964775170
+        #[cfg(feature = "esp32s2")]
+        $crate::esp_alloc::heap_allocator!(#[esp_hal::ram(reclaimed)] size: ::ssh_stamp::settings::HEAP_SIZE);
+        #[cfg(not(feature = "esp32s2"))]
+        $crate::esp_alloc::heap_allocator!(size: ::ssh_stamp::settings::HEAP_SIZE);
+    };
+}
+
+/// Starts the esp-rtos scheduler on `TIMG1` for original ESP32 and `SYSTIMER` everywhere
+/// else. This  registers the embassy time driver, so it must run before anything that
+/// uses `embassy-time`.
+///
+/// The scheduler uses the software interrupt 0 for context switching, so the
+/// macro consumes `SW_INTERRUPT`: [`SoftwareInterrupt<1>`](SoftwareInterrupt).
+#[macro_export]
+macro_rules! start_rtos {
+    ($peripherals:ident) => {{
+        let sw_int = ::esp_hal::interrupt::software::SoftwareInterruptControl::new(
+            $peripherals.SW_INTERRUPT,
+        );
+        #[cfg(feature = "esp32")]
+        ::esp_rtos::start(
+            ::esp_hal::timer::timg::TimerGroup::new($peripherals.TIMG1).timer0,
+            sw_int.software_interrupt0,
+        );
+        #[cfg(not(feature = "esp32"))]
+        ::esp_rtos::start(
+            ::esp_hal::timer::systimer::SystemTimer::new($peripherals.SYSTIMER).alarm0,
+            sw_int.software_interrupt0,
+        );
+        sw_int.software_interrupt1
+    }};
+}
+
+/// The ssh-stamp boot sequence, which does heap allocation, `esp_hal::init`,
+/// configures the entropy source, flash storage and the esp-rtos scheduler.
+///
+/// The `Peripherals` struct cannot be returned once fields have been moved
+/// out of it, so the caller names the bindings and the macro introduces
+/// them into scope, e.g:
+///
+/// ```ignore
+/// ssh_stamp_esp32::boot!(peripherals, rng, entropy_source, sw_int1);
+/// ```
+#[macro_export]
+macro_rules! boot {
+    ($peripherals:ident, $rng:ident, $entropy_source:ident, $sw_int1:ident) => {
+        $crate::init_heap!();
+        $crate::bench::log_heap("boot");
+
+        // Note that benches do depend on a stable clock speed across comparisons. The default
+        // shouldn't change much, but theoretically an upgrade could change it.
+        let $peripherals = ::esp_hal::init(::esp_hal::Config::default());
+
+        // Enable true random number generation before the config is created, so
+        // the WiFi password and SSH host key have cryptographically secure values.
+        let ($rng, $entropy_source) = $crate::init_entropy!($peripherals);
+
+        $crate::flash_init($peripherals.FLASH);
+        let $sw_int1 = $crate::start_rtos!($peripherals);
+    };
+}
+
+/// Starts the `InterruptExecutor` on the [`SoftwareInterrupt<1>`](SoftwareInterrupt) left over
+/// from  [`start_rtos!`](macro@crate::start_rtos), and returns its spawner.
+pub fn start_interrupt_executor(sw_int1: SoftwareInterrupt<'static, 1>) -> SendSpawner {
+    static INT_EXECUTOR: StaticCell<InterruptExecutor<1>> = StaticCell::new(); // 0 is used for esp_rtos
+
+    let interrupt_executor = INT_EXECUTOR.init_with(|| InterruptExecutor::new(sw_int1));
+    cfg_if::cfg_if! {
+        if #[cfg(any(feature = "esp32", feature = "esp32s2", feature = "esp32s3"))] {
+            let interrupt_spawner = interrupt_executor.start(Priority::Priority3);
+        } else if #[cfg(feature = "esp32c6")] {
+            let interrupt_spawner = interrupt_executor.start(Priority::Priority10);
+        } else {
+            let interrupt_spawner = interrupt_executor.start(Priority::Priority1);
+        }
+    }
+    interrupt_spawner
+}

--- a/ssh-stamp-esp32/src/boot.rs
+++ b/ssh-stamp-esp32/src/boot.rs
@@ -75,7 +75,10 @@ macro_rules! start_rtos {
 macro_rules! boot {
     ($peripherals:ident, $rng:ident, $entropy_source:ident, $sw_int1:ident) => {
         $crate::init_heap!();
+        $crate::esp_bootloader_esp_idf::esp_app_desc!();
+        $crate::esp_println::logger::init_logger_from_env();
         $crate::bench::log_heap("boot");
+        $crate::log::debug!("HSM: initialising peripherals");
 
         // Note that benches do depend on a stable clock speed across comparisons. The default
         // shouldn't change much, but theoretically an upgrade could change it.

--- a/ssh-stamp-esp32/src/lib.rs
+++ b/ssh-stamp-esp32/src/lib.rs
@@ -43,11 +43,14 @@ pub use rng::{
 pub use timer::EspTimer;
 pub use uart::{BufferedUart, EspUartPins, UART_BUF, UART_SIGNAL, spawn_uart, uart_task};
 
-// Re-exported for the `getrandom_backend!` expansion.
+// These re-exports are nice to have for macro expansions, including `getrandom_backend!`,
+// `init_heap!`, `start_rtos!` and `boot!, as they mean the calling crate doesn't have to
+// have these as direct dependencies.
 pub use getrandom;
-
-// Re-exported for the `init_heap!` expansion.
 pub use esp_alloc;
+pub use esp_hal;
+pub use esp_rtos;
+pub use ssh_stamp;
 
 /// Read the device's hardware MAC address from eFuse.
 #[must_use]

--- a/ssh-stamp-esp32/src/lib.rs
+++ b/ssh-stamp-esp32/src/lib.rs
@@ -47,9 +47,12 @@ pub use uart::{BufferedUart, EspUartPins, UART_BUF, UART_SIGNAL, spawn_uart, uar
 // `init_heap!`, `start_rtos!` and `boot!, as they mean the calling crate doesn't have to
 // have these as direct dependencies.
 pub use esp_alloc;
+pub use esp_bootloader_esp_idf;
 pub use esp_hal;
+pub use esp_println;
 pub use esp_rtos;
 pub use getrandom;
+pub use log;
 pub use ssh_stamp;
 
 /// Read the device's hardware MAC address from eFuse.

--- a/ssh-stamp-esp32/src/lib.rs
+++ b/ssh-stamp-esp32/src/lib.rs
@@ -46,10 +46,10 @@ pub use uart::{BufferedUart, EspUartPins, UART_BUF, UART_SIGNAL, spawn_uart, uar
 // These re-exports are nice to have for macro expansions, including `getrandom_backend!`,
 // `init_heap!`, `start_rtos!` and `boot!, as they mean the calling crate doesn't have to
 // have these as direct dependencies.
-pub use getrandom;
 pub use esp_alloc;
 pub use esp_hal;
 pub use esp_rtos;
+pub use getrandom;
 pub use ssh_stamp;
 
 /// Read the device's hardware MAC address from eFuse.

--- a/ssh-stamp-esp32/src/lib.rs
+++ b/ssh-stamp-esp32/src/lib.rs
@@ -18,6 +18,7 @@
 extern crate alloc;
 
 pub mod bench;
+mod boot;
 #[cfg(feature = "can")]
 mod can;
 pub mod flash;
@@ -28,15 +29,25 @@ mod rng;
 mod timer;
 mod uart;
 
+pub use boot::start_interrupt_executor;
 #[cfg(feature = "can")]
 pub use can::{BufferedCan, CAN_BUF, EspCanPins, can_task};
 pub use flash::{EspOtaWriter, FlashBuffer, get_flash_n_buffer, init as flash_init};
 pub use hash::EspHmac;
 pub use network::{EspWifi, accept_requests, dhcp_server, net_up, wifi_up};
 pub use platform::EspPlatform;
-pub use rng::{EspRng, fill_bytes as rng_fill_bytes, register_custom_rng};
+pub use rng::{
+    EntropySource, EspRng, entropy_source_active, fill_bytes as rng_fill_bytes, init_entropy,
+    register_custom_rng,
+};
 pub use timer::EspTimer;
-pub use uart::{BufferedUart, EspUartPins, UART_BUF, UART_SIGNAL, uart_task};
+pub use uart::{BufferedUart, EspUartPins, UART_BUF, UART_SIGNAL, spawn_uart, uart_task};
+
+// Re-exported for the `getrandom_backend!` expansion.
+pub use getrandom;
+
+// Re-exported for the `init_heap!` expansion.
+pub use esp_alloc;
 
 /// Read the device's hardware MAC address from eFuse.
 #[must_use]

--- a/ssh-stamp-esp32/src/rng.rs
+++ b/ssh-stamp-esp32/src/rng.rs
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2026 Angus Gratton <gus@projectgus.com>
 // SPDX-FileCopyrightText: 2026 Gabriel Ku Wei Bin <gabriel.ku@fsfe.org>
 // SPDX-FileCopyrightText: 2026 Anthony Tambasco <anthony.tambasco@fastmail.com>
+// SPDX-FileCopyrightText: 2026 Marko Malenic <mmalenic1@gmail.com>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 
@@ -19,10 +20,12 @@
 //! links an `extern "Rust"` symbol that must be defined exactly once in the
 //! whole program.
 //!
-//! Defining that symbol requires `unsafe`, so it lives in the port binary
-//! (`src/bin/ssh-stamp-esp32.rs`) — which is also where getrandom's own
-//! documentation says it belongs — and simply forwards to [`fill_bytes`]
-//! below. That keeps this crate `#![forbid(unsafe_code)]`.
+//! Defining that symbol requires `unsafe`, which this crate forbids, and
+//! binaries cannot link each other's definitions. So, the
+//! [`getrandom_backend!`](macro@crate::getrandom_backend) packages the
+//! definition as a macro that every binary invokes once. The `unsafe`
+//! only compiles where the macro is expanded, keeping this crate
+//! `#![forbid(unsafe_code)]`.
 
 use core::cell::RefCell;
 use core::future::{Future, ready};
@@ -30,6 +33,11 @@ use core::future::{Future, ready};
 use embassy_sync::blocking_mutex::Mutex;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use esp_hal::rng::Rng;
+#[cfg(not(any(feature = "esp32c5", feature = "esp32c61")))]
+use esp_hal::{
+    peripherals::{ADC1, RNG},
+    rng::{Trng, TrngSource},
+};
 use ssh_stamp_hal::{HalError, RngHal};
 use static_cell::StaticCell;
 
@@ -41,6 +49,120 @@ static RNG_MUTEX: Mutex<CriticalSectionRawMutex, RefCell<Option<&'static mut Rng
 pub fn register_custom_rng(rng: Rng) {
     let rng_ref = RNG.init(rng);
     RNG_MUTEX.lock(|t| t.borrow_mut().replace(rng_ref));
+}
+
+/// This is a wrapper that sets up the boot entropy source.
+///
+/// On chips with a TRNG this holds the SAR ADC entropy source that
+/// [`init_entropy()`] enables. The RNG register only has randomness
+/// while a source is active, and the ADC source is what occurs on boot.
+///
+/// Dropping this guard switches off the source. This handover is required
+/// because the ADC source needs to be switched off "before RF subsystem
+/// features, ADC, or I2S (ESP32 only) are initialized" and that it's "not
+/// safe to use if any other subsystem is accessing the RF subsystem or
+/// the ADC at the same time".
+///
+/// On the ESP32-C5/C61, there is no TRNG driver yet, so the guard is empty.
+///
+/// See: <https://docs.espressif.com/projects/esp-idf/en/stable/esp32/api-reference/system/random.html>
+#[must_use = "dropping switches the boot-time entropy source off"]
+pub struct EntropySource {
+    #[cfg(not(any(feature = "esp32c5", feature = "esp32c61")))]
+    _source: TrngSource<'static>,
+}
+
+// TODO: The ESP32-C5/C61 TRNG is not yet available in esp-hal 1.1.1. Once
+// https://github.com/esp-rs/esp-hal/pull/4978 lands in a release, remove
+// this cfg_if! and use Trng/TrngSource unconditionally for all targets.
+cfg_if::cfg_if! {
+    if #[cfg(any(feature = "esp32c5", feature = "esp32c61"))] {
+        /// Registers the hardware RNG with `getrandom`.
+        ///
+        /// The ESP32-C5/C61 have no TRNG in esp-hal yet, so the RNG register
+        /// is all the firmware has at boot. This means that anything using
+        /// this before the radio is up is only as good as that register.
+        ///
+        /// Call through [`init_entropy!`](macro@crate::init_entropy), which moves =
+        /// the peripherals needed.
+        pub fn init_entropy() -> (Rng, EntropySource) {
+            log::warn!(
+                "No TRNG on this chip, RNG is not cryptographically secure until the radio is up"
+            );
+
+            let rng = Rng::new();
+            register_custom_rng(rng);
+
+            (rng, EntropySource {})
+        }
+
+        /// Whether an entropy source is currently using the RNG register.
+        /// Always true for esp32c5/c61 as there is no driver.
+        #[must_use]
+        pub fn entropy_source_active() -> bool {
+            true
+        }
+    } else {
+        /// Enables true random number generation and registers the hardware
+        /// RNG with `getrandom`, which is used by the SSH host key and
+        /// the `WiFi` password.
+        ///
+        /// The RNG register only produces true random numbers while an
+        /// entropy source is active. These are the SAR ADC source enabled here,
+        /// which covers early boot, and the RF system, which covers once `WiFi`
+        /// is up. The returned [`Rng`] doesn't have this information, it just
+        /// uses whichever source is active at the time to decide the quality.
+        ///
+        /// This means that the [`EntropySource`] must be kept alive until the radio
+        /// takes over, and then it should be dropped.
+        ///
+        /// Call through [`init_entropy!`](macro@crate::init_entropy), which moves
+        /// the peripherals the active chip needs in.
+        ///
+        /// See: <https://github.com/brainstorm/ssh-stamp/issues/10>
+        /// See: <https://github.com/esp-rs/esp-hal/pull/3829>
+        ///
+        /// # Panics
+        ///
+        /// Panics if the TRNG is unavailable, which cannot happen as
+        /// the source is created first.
+        pub fn init_entropy(
+            rng: RNG<'static>,
+            adc: ADC1<'static>,
+        ) -> (Rng, EntropySource) {
+            let source = TrngSource::new(rng, adc);
+            let trng = Trng::try_new().expect("TrngSource was just created");
+            let handle = trng.downgrade();
+
+            register_custom_rng(handle);
+
+            (handle, EntropySource { _source: source })
+        }
+
+        /// Whether an entropy source is currently using the RNG register.
+        ///
+        /// Used to guard call sites with `debug_assert!`.
+        #[must_use]
+        pub fn entropy_source_active() -> bool {
+            TrngSource::is_enabled()
+        }
+    }
+}
+
+/// Creates the boot entropy source and registers the hardware RNG with
+/// `getrandom`.
+///
+/// This is a convenience macro that allows creating the source without having
+/// to specify the features manually.
+#[macro_export]
+macro_rules! init_entropy {
+    ($peripherals:expr) => {{
+        #[cfg(any(feature = "esp32c5", feature = "esp32c61"))]
+        let out = $crate::init_entropy();
+        #[cfg(not(any(feature = "esp32c5", feature = "esp32c61")))]
+        let out = $crate::init_entropy($peripherals.RNG, $peripherals.ADC1);
+        out
+    }};
 }
 
 /// ESP32 RNG implementation
@@ -73,8 +195,8 @@ impl RngHal for EspRng {
 /// Safe half of the `getrandom` custom backend: fills `buf` from the
 /// registered hardware RNG.
 ///
-/// The binary's `__getrandom_v03_custom` shim forwards here; see the module
-/// docs for why the split exists.
+/// The `__getrandom_v03_custom` that  [`getrandom_backend!`](macro@crate::getrandom_backend)
+/// defines forwards here. See the module docs for why the split exists.
 ///
 /// # Errors
 ///
@@ -90,4 +212,29 @@ pub fn fill_bytes(buf: &mut [u8]) -> Result<(), getrandom::Error> {
         rng.read(buf);
         Ok(())
     })
+}
+
+/// Defines the `getrandom` custom backend, which is an `unsafe extern "Rust"` symbol
+/// that fills a buffer from the hardware RNG registered by [`init_entropy!`](macro@crate::init_entropy).
+/// This is what the SSH host key and the `WiFi` password use, so it must be
+/// a true and secure source of randomness.
+#[macro_export]
+macro_rules! getrandom_backend {
+    () => {
+        #[unsafe(no_mangle)]
+        unsafe extern "Rust" fn __getrandom_v03_custom(
+            dest: *mut u8,
+            len: usize,
+        ) -> Result<(), $crate::getrandom::Error> {
+            // SAFETY: getrandom guarantees `dest` is valid for writes of
+            // `len` bytes. The buffer may be uninitialised, so it is zeroed
+            // before a slice is formed over it, as getrandom's documentation
+            // prescribes.
+            let buf = unsafe {
+                ::core::ptr::write_bytes(dest, 0, len);
+                ::core::slice::from_raw_parts_mut(dest, len)
+            };
+            $crate::rng_fill_bytes(buf)
+        }
+    };
 }

--- a/ssh-stamp-esp32/src/uart.rs
+++ b/ssh-stamp-esp32/src/uart.rs
@@ -18,6 +18,7 @@
 
 use core::future::Future;
 
+use embassy_executor::SendSpawner;
 use embassy_sync::pipe::TryWriteError;
 use embassy_sync::signal::Signal;
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, pipe::Pipe};
@@ -224,4 +225,26 @@ pub async fn uart_task(
     let uart = uart.with_rx(pins.rx).with_tx(pins.tx).into_async();
 
     uart_buf.run(uart).await;
+}
+
+/// Creates the [`BufferedUart`] singleton and spawns [`uart_task`] on the
+/// given spawner, returning the buffer the rest of the system talks to. The
+/// firmware feeds it the spawner from
+/// [`start_interrupt_executor`](crate::start_interrupt_executor), so the
+/// task runs at interrupt priority. The task waits on [`UART_SIGNAL`] before
+/// touching the hardware.
+///
+/// # Panics
+///
+/// Panics if called more than once per boot: the [`BufferedUart`] singleton
+/// and the task can each only be created once.
+pub fn spawn_uart(
+    spawner: SendSpawner,
+    uart1: UART1<'static>,
+    pins: EspUartPins<'static>,
+    params: UartParams,
+) -> &'static BufferedUart {
+    let uart_buf = UART_BUF.init_with(BufferedUart::new);
+    spawner.spawn(uart_task(uart_buf, uart1, pins, params).expect("uart_task spawn failed"));
+    uart_buf
 }

--- a/ssh-stamp-esp32/src/uart.rs
+++ b/ssh-stamp-esp32/src/uart.rs
@@ -101,7 +101,18 @@ impl BufferedUart {
             let rd_to = async {
                 loop {
                     let n = self.outward.read(&mut tx_buf).await;
-                    let _ = uart_tx.write_async(&tx_buf[..n]).await;
+
+                    // This must take into consideration the length returned by `write_async`,
+                    // as it may be less than the full buffer. Follow-up loop iterations
+                    // then write any remainder.
+                    let mut tx_slice = &tx_buf[..n];
+                    while !tx_slice.is_empty() {
+                        let Ok(written) = uart_tx.write_async(tx_slice).await else {
+                            break;
+                        };
+
+                        tx_slice = &tx_slice[written..];
+                    }
                 }
             };
 

--- a/xtask/src/board.rs
+++ b/xtask/src/board.rs
@@ -342,6 +342,52 @@ impl Target {
             Target::Chip(chip) => chip.build_std,
         }
     }
+
+    /// The `SoC` the target runs on.
+    pub fn soc(&self) -> &'static str {
+        match self {
+            Target::Board(board) => board.soc,
+            Target::Chip(chip) => chip.name,
+        }
+    }
+
+    /// The cargo arguments that select the HIL test crate for this target.
+    pub fn hil_selection_args(&self) -> Vec<String> {
+        let mut arguments = vec![
+            "--target".into(),
+            self.triple().into(),
+            "-p".into(),
+            "ssh-stamp-esp32-hil".into(),
+            "--release".into(),
+            "--no-default-features".into(),
+            "--features".into(),
+            self.feature().into(),
+        ];
+
+        if self.build_std() {
+            arguments.push("-Z".into());
+            arguments.push("build-std=core,alloc".into());
+            // This is required because otherwise cargo would error due to a
+            // clash with the workspace release profile setting `panic = "abort"`.
+            arguments.push("-Z".into());
+            arguments.push("panic-abort-tests".into());
+        }
+
+        arguments
+    }
+
+    /// The environment variable that overrides the cargo runner.
+    pub fn runner_env(&self) -> String {
+        format!(
+            "CARGO_TARGET_{}_RUNNER",
+            self.triple().to_uppercase().replace('-', "_")
+        )
+    }
+
+    /// The probe-rs run that flashes and runs each HIL test.
+    pub fn hil_runner(&self) -> String {
+        format!("probe-rs run --preverify --chip {}", self.soc())
+    }
 }
 
 impl Chip {

--- a/xtask/src/cmd/cargo.rs
+++ b/xtask/src/cmd/cargo.rs
@@ -6,6 +6,9 @@
 //! This is the forwarding cargo command wrapper. Any cargo command can be forwarded
 //! from the xtask in order to target a specific board or chip:
 //! `cargo xtask <target> <cargo command> [args...]`.
+//!
+//! `test` has a specific behaviour, it selects the `ssh-stamp-esp32-hil` crate
+//! and runs the embedded tests on hardware using probe-rs.
 
 use crate::board::Target;
 use crate::cmd::shell;
@@ -28,16 +31,28 @@ pub fn run(argv: &[String]) -> Result<()> {
 
     let sh = shell()?;
     let toolchain = format!("+{}", target.toolchain());
-    let selection = target.selection_args();
+
+    let hil = action == "test";
+    let selection = if hil {
+        target.hil_selection_args()
+    } else {
+        target.selection_args()
+    };
     let trailing = &argv[2..];
 
     eprintln!("=== {action} {} ===", target.name());
 
-    cmd!(
+    let mut command = cmd!(
         sh,
         "cargo {toolchain} {action} {selection...} {trailing...}"
     )
-    .env("CARGO_TARGET_DIR", target.target_dir())
-    .run()
-    .with_context(|| format!("cargo {action} for {} failed", target.name()))
+    .env("CARGO_TARGET_DIR", target.target_dir());
+
+    if hil {
+        command = command.env(target.runner_env(), target.hil_runner());
+    }
+
+    command
+        .run()
+        .with_context(|| format!("cargo {action} for {} failed", target.name()))
 }


### PR DESCRIPTION
This PR introduces HIL tests using the `embedded-test` framework. 

This is structured as an additional crate, matching similar patterns is esp-hal. The crate is compiled for a board or chip target, and the tests are run.

### Changes
* Add uart and flash HIL tests. The `uart` test requires a board definition with pins, whereas the `flash` test only requires a chip target, hence the asymmetry in the feature selection and required features.
* The tests are run through `cargo xtask <board/chip> test`. This requires special handling to forward the correct parameters to embedded-test. This means that it overrides the regular forwarding logic for `cargo xtask <board> test` which would have otherwise run libtest framework tests. However this is okay, as libtest was never a valid choice, as these are no_std targets.
* The main change to the firmware binary code, is introducing a bunch of macros for the boot process, including the getrandom backend, heap initialization, rtos, and the interrupt handler. The reason this is a necessary change is because it allows these components to actually be testable, otherwise the tests would repeat what the firmware source already defines. They are mostly macros because peripherals and pins are board-specific, and also get consumed when using, so it's not possible to write them as regular functions.
    * The refactor to the ssh-stamp-esp32 source code is intended to be identical behaviour wise to what it was previously (except fixes below), it just has macro definitions that copy the behaviour to re-usable components.
* I've also added more features and targets to the CI clippy linting.
    
### Fixes
* These tests found a bug, which is a nice side-effect (I like it when tests are actually useful). The `write_async` loop was not considering the returned bytes written, causing bytes to be dropped when they should have carried over to another iteration. This has now been fixed.
* There was also a bug with the `ipv6` feature, as it didn't enable the `embassy-net/proto-ipv6`, causing the build to fail, as this feature is required for structs like `StaticConfigV6`.